### PR TITLE
PR with squashed and rebased pms-ni commits on master

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -257,6 +257,12 @@ version = "0.2.11"
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "0.2.11"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PowerModels]]
 git-tree-sha1 = "c732dcd768d05f27d9ba3dae7086e97af6f50527"
@@ -283,6 +289,19 @@ repo-rev = "master"
 repo-url = "https://github.com/NREL/PowerSystems.jl.git"
 uuid = "c512b964-a17e-11e8-344c-11d7c2eac237"
 version = "0.2.1"
+
+    [PowerSystems.deps]
+    AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+    CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+    Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+    DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
+    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
     [PowerSystems.deps]
     AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,8 @@ PowerSystems = "c512b964-a17e-11e8-344c-11d7c2eac237"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [extras]
+Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Memento"]

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -29,7 +29,7 @@ using JuMP
 using TimeSeries
 using PowerSystems
 import PowerModels
-using Compat
+import InfrastructureModels
 using GLPK
 using MathOptInterface
 #using Clp
@@ -44,6 +44,7 @@ using Dates
 #################################################################################
 # Type Alias From other Packages
 const PM = PowerModels
+const IM = InfrastructureModels
 const NetworkModel = PM.AbstractPowerFormulation
 const PS = PowerSimulations
 const MOI = MathOptInterface
@@ -62,7 +63,6 @@ const fix_resource = Union{PowerSystems.RenewableFix, PowerSystems.HydroFix}
 
 #################################################################################
 # Includes
-
 
 #Abstract Models
 include("network_models/networks.jl")
@@ -83,6 +83,7 @@ include("utils/cost_addition.jl")
 include("utils/timeseries_injections.jl")
 include("utils/device_injections.jl")
 include("utils/device_retreval.jl")
+include("utils/pm_translator.jl")
 
 #Device Modeling components
 include("device_models/common.jl")
@@ -99,6 +100,8 @@ include("service_models/reserves.jl")
 #Network related components
 include("network_models/copperplate_balance.jl")
 include("network_models/nodal_balance.jl")
+include("network_models/powermodels_balance.jl")
+
 
 #Device constructors
 include("component_constructors/thermalgeneration_constructor.jl")

--- a/src/base/model_constructors.jl
+++ b/src/base/model_constructors.jl
@@ -1,4 +1,4 @@
-function buildmodel!(sys::PowerSystems.PowerSystem, op_model::PowerOperationModel; args...)
+function buildmodel!(op_model::PowerOperationModel, sys::PowerSystems.PowerSystem; args...)
 
     #TODO: Add check model spec vs data functions before trying to build
 
@@ -12,7 +12,7 @@ function buildmodel!(sys::PowerSystems.PowerSystem, op_model::PowerOperationMode
         for category in op_model.demand
             constructdevice!(op_model.model, netinjection, category.device, category.formulation, op_model.transmission, sys; args...)
         end
-    end 
+    end
 
     #=
     for category in op_model.storage

--- a/src/component_constructors/branch_constructor.jl
+++ b/src/component_constructors/branch_constructor.jl
@@ -1,24 +1,10 @@
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{B}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {B <: PowerSystems.Branch, D <: AbstractBranchForm, S <: PM.AbstractDCPForm}
+function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{B}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {B <: PowerSystems.Branch, D <: AbstractBranchForm, S <: AbstractFlowForm}
 
     flowvariables(m, system_formulation, sys.branches, sys.time_periods)
 
     thermalflowlimits(m, system_formulation, sys.branches, sys.time_periods)
 
-    nodalflowbalance(m, netinjection, system_formulation, sys)
-
 end
-
-#=
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.Branch}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractBranchForm, S <: PM.AbstractDCPLLForm}
-
-    flowvariables(m, system_formulation, sys.branches, sys.time_periods)
-
-    thermalflowlimits(m, system_formulation, sys.branches, sys.time_periods)
-
-    nodalflowbalance(m, netinjection, system_formulation, sys)
-
-end
-=#
 
 function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{B}, category_formulation::Type{PiLine}, system_formulation::Type{StandardPTDF}, sys::PowerSystems.PowerSystem; args...) where {B <: PowerSystems.Branch}
 
@@ -33,7 +19,5 @@ function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, catego
     thermalflowlimits(m, system_formulation, sys.branches, sys.time_periods)
 
     dc_networkflow(m, netinjection, PTDF)
-
-    nodalflowbalance(m, netinjection, system_formulation, sys)
 
 end

--- a/src/component_constructors/thermalgeneration_constructor.jl
+++ b/src/component_constructors/thermalgeneration_constructor.jl
@@ -31,9 +31,9 @@ function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, catego
 end
 
 
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{ThermalRampLimitDispatch}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractDCPowerModel}
+function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{ThermalRampLimitDispatch}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: PM.AbstractPowerFormulation}
 
-    constructdevice!(m, netinjection, category, category_formulation, PM.AbstractPowerFormulation, sys; args...)
+    constructdevice!(m, netinjection, category, AbstractThermalDispatchForm, PM.AbstractPowerFormulation, sys; args...)
 
     #rampargs = pairs((;(k=>v for (k,v) in pairs(args) if k in [:initalpower])...))
 

--- a/src/device_models/branches/flow_variables.jl
+++ b/src/device_models/branches/flow_variables.jl
@@ -5,7 +5,7 @@ function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Arra
 
     time_range = 1:time_periods
 
-    fbr = @variable(m, fbr[on_set,time_range])
+    fbr = @variable(m, fbr[on_set,time_range], start = 0.0)
 
 end
 
@@ -16,8 +16,8 @@ function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Arra
 
     time_range = 1:time_periods
 
-    fbr_to = @variable(m, fbr_to[on_set,time_range])
-    fbr_fr = @variable(m, fbr_fr[on_set,time_range])
+    fbr_to = @variable(m, fbr_to[on_set,time_range], start = 0.0)
+    fbr_fr = @variable(m, fbr_fr[on_set,time_range], start = 0.0)
 
 end
 
@@ -27,10 +27,10 @@ function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Arra
 
     time_range = 1:time_periods
 
-    active_fbr_to = @variable(m, active_fbr_to[on_set,time_range])
-    active_fbr_fr = @variable(m, active_fbr_fr[on_set,time_range])
+    active_fbr_to = @variable(m, active_fbr_to[on_set,time_range], start = 0.0)
+    active_fbr_fr = @variable(m, active_fbr_fr[on_set,time_range], start = 0.0)
 
-    reactive_fbr_to = @variable(m, reactive_fbr_to[on_set,time_range])
-    reactive_fbr_fr = @variable(m, reactive_fbr_fr[on_set,time_range])
+    reactive_fbr_to = @variable(m, reactive_fbr_to[on_set,time_range], start = 0.0)
+    reactive_fbr_fr = @variable(m, reactive_fbr_fr[on_set,time_range], start = 0.0)
 
 end

--- a/src/device_models/common/variable_cost.jl
+++ b/src/device_models/common/variable_cost.jl
@@ -22,7 +22,7 @@ end
 
 function pwlgencost(m::JuMP.Model, variable::VariableRef, cost_component::Array{Tuple{Float64, Float64}})
 
-    pwlvars = @variable(m, [i = 1:(length(cost_component)-1)], base_name = "pwl_{$(variable)}")
+    pwlvars = @variable(m, [i = 1:(length(cost_component)-1)], base_name = "pwl_{$(variable)}", start = 0.0, lower_bound = 0.0, upper_bound = (cost_component[i+1][1] - cost_component[i][1]))
      for (ix, pwlvar) in enumerate(pwlvars)
         c = @constraint(m, pwlvar <= cost_component[ix + 1][2])
         c = @constraint(m, pwlvar >= 0)

--- a/src/device_models/electric_loads/load_variables.jl
+++ b/src/device_models/electric_loads/load_variables.jl
@@ -4,7 +4,7 @@ function activepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods::
 
     t = 1:time_periods
 
-    p_cl = @variable(m, p_cl[on_set,t] >= 0.0) # Power of controllable loads
+    p_cl = @variable(m, p_cl[on_set,t] >= 0.0, start = 0.0) # Power of controllable loads
 
     return p_cl
 end
@@ -15,7 +15,7 @@ function reactivepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods
 
     t = 1:time_periods
 
-    q_cl = @variable(m, q_cl[on_set,t] >= 0.0) # Power of controllable loads
+    q_cl = @variable(m, q_cl[on_set,t] >= 0.0, start = 0.0) # Power of controllable loads
 
     return q_cl
 end

--- a/src/device_models/renewable_generation/renewable_variables.jl
+++ b/src/device_models/renewable_generation/renewable_variables.jl
@@ -4,7 +4,7 @@ function activepowervariables(m::JuMP.Model, devices::Array{R,1}, time_periods::
 
     t = 1:time_periods
 
-    p_re = @variable(m, p_re[on_set,t] >= 0)
+    p_re = @variable(m, p_re[on_set,t] >= 0.0, start = 0.0)
 
     return p_re
 
@@ -16,7 +16,7 @@ function reactivepowervariables(m::JuMP.Model, devices::Array{R,1}, time_periods
 
     t = 1:time_periods
 
-    q_re = @variable(m, q_re[on_set,t]) # Power output of generators
+    q_re = @variable(m, q_re[on_set,t], start = 0.0) # Power output of generators
 
     return q_re
 end

--- a/src/device_models/thermal_generation/ramping_constraints.jl
+++ b/src/device_models/thermal_generation/ramping_constraints.jl
@@ -2,10 +2,10 @@
 """
 This function adds the ramping limits of generators when there are no CommitmentVariables
 """
-function rampconstraints(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm, S <: AbstractDCPowerModel}
+function rampconstraints(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{ThermalRampLimitDispatch}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, S <: PM.AbstractPowerFormulation}
 
     devices = [d for d in devices if !isa(d.tech.ramplimits,Nothing)]
-    
+
     if !isempty(devices)
 
         p_th = m[:p_th]
@@ -92,10 +92,9 @@ function rampconstraints(m::JuMP.Model, devices::Array{T,1}, device_formulation:
 
     else
         @warn "There are no generators with Ramping Limits Data in the System"
-        
     end
-        
-    
+
+
     return m
 
 end

--- a/src/device_models/thermal_generation/thermal_variables.jl
+++ b/src/device_models/thermal_generation/thermal_variables.jl
@@ -9,7 +9,7 @@ function activepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods::
 
     t = 1:time_periods
 
-    p_th = @variable(m, p_th[on_set,t]) # Power output of generators
+    p_th = @variable(m, p_th[on_set,t], start = 0.0) # Power output of generators
 
     return p_th
 end
@@ -23,7 +23,7 @@ function reactivepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods
 
     t = 1:time_periods
 
-    q_th = @variable(m, q_th[on_set,t]) # Power output of generators
+    q_th = @variable(m, q_th[on_set,t], start = 0.0) # Power output of generators
 
     return q_th
 end

--- a/src/network_models/copperplate_balance.jl
+++ b/src/network_models/copperplate_balance.jl
@@ -6,7 +6,7 @@ function copperplatebalance(m::JuMP.Model, netinjection::BalanceNamedTuple, time
     cpn = JuMP.JuMPArray(Array{ConstraintRef}(undef,time_periods), 1:time_periods)
 
     for t in 1:time_periods
-        # TODO: Check is sum() is the best way to do this in terms of speed. 
+        # TODO: Check is sum() is the best way to do this in terms of speed.
         cpn[t] = @constraint(m, sum(netinjection.var_active[:,t]) == timeseries_netinjection[t])
     end
 

--- a/src/network_models/networks.jl
+++ b/src/network_models/networks.jl
@@ -1,6 +1,6 @@
 #First Level Abstraction
 
-const AbstractACPowerModel = Union{PM.AbstractACPForm, PM.AbstractACRForm}
+const AbstractACPowerModel = Union{PM.AbstractACPForm, PM.AbstractACRForm, PM.AbstractWRForm}
 
 const AbstractDCPowerModel = Union{PM.AbstractDCPForm, PM.AbstractDCPLLForm} #Adopt from PowerModels, LL -> Line Losses
 
@@ -12,26 +12,26 @@ abstract type CopperPlatePowerModel <: PM.AbstractPowerFormulation end
 
 const StandardAC = PM.StandardACPForm
 
-#Second Level Abstraction DC 
+#Second Level Abstraction DC
 
 ##This line is from PowerModels, needs to be removed later
 
-abstract type DCAngleForm <: PM.AbstractDCPForm end
+abstract type DCAngleForm <: PM.DCPlosslessForm end
 
 abstract type DCAngleLLForm <: PM.AbstractDCPLLForm end
 
 #abstract type StandardDCPLLForm<: PM.AbstractDCPLLForm end
 
-abstract type AbstractFlowForm <: PM.AbstractDCPForm end
+abstract type AbstractFlowForm <: PM.NFAForm end
 
 abstract type AbstractFlowLLForm <: PM.AbstractDCPLLForm end
 
 #Third Level of Abstraction.
 
-abstract type StandardPTDF <: AbstractFlowForm end    
+abstract type StandardPTDF <: AbstractFlowForm end
 
 abstract type StandardPTDFLL <: AbstractFlowLLForm end
 
-abstract type StandardNetFlow <: AbstractFlowForm end    
+abstract type StandardNetFlow <: AbstractFlowForm end
 
 abstract type StandardNetFlowLL <: AbstractFlowLLForm end

--- a/src/network_models/powermodels_balance.jl
+++ b/src/network_models/powermodels_balance.jl
@@ -1,0 +1,208 @@
+#################################################################################
+# Questions
+#
+# - why do exported functions (e.g. ids, var, con, ref) need pacakge qualification?
+# - why do non-qualified exported functions (e.g. ids, var) still throw warnings?
+#
+#
+# Comments
+#
+# - Ideally the net_injection variables would be bounded.  This can be done using an adhoc data model extention
+#
+
+
+#################################################################################
+# Model Definitions
+
+""
+function build_nip_model(data::Dict{String,Any}, model_constructor; multinetwork=true, kwargs...)
+    return PM.build_generic_model(data, model_constructor, post_nip; multinetwork=multinetwork, kwargs...)
+end
+
+
+
+""
+function post_nip(pm::PM.GenericPowerModel)
+    for (n, network) in PM.nws(pm)
+        @assert !PM.ismulticonductor(pm, nw=n)
+        PM.variable_voltage(pm, nw=n)
+        variable_net_injection(pm, nw=n)
+        PM.variable_branch_flow(pm, nw=n)#, bounded=false)
+        PM.variable_dcline_flow(pm, nw=n)
+
+        PM.constraint_voltage(pm, nw=n)
+
+        for i in PM.ids(pm, :ref_buses, nw=n)
+            PM.constraint_theta_ref(pm, i, nw=n)
+        end
+
+        for i in PM.ids(pm, :bus, nw=n)
+            constraint_kcl_ni(pm, i, nw=n)
+        end
+
+        for i in PM.ids(pm, :branch, nw=n)
+            PM.constraint_ohms_yt_from(pm, i, nw=n)
+            PM.constraint_ohms_yt_to(pm, i, nw=n)
+
+            PM.constraint_voltage_angle_difference(pm, i, nw=n)
+
+            PM.constraint_thermal_limit_from(pm, i, nw=n)
+            PM.constraint_thermal_limit_to(pm, i, nw=n)
+        end
+
+        for i in PM.ids(pm, :dcline)
+            PM.constraint_dcline(pm, i, nw=n)
+        end
+    end
+end
+
+
+""
+function build_nip_expr_model(data::Dict{String,Any}, model_constructor; multinetwork=true, kwargs...)
+    return PM.build_generic_model(data, model_constructor, post_nip_expr; multinetwork=multinetwork, kwargs...)
+end
+
+""
+function post_nip_expr(pm::PM.GenericPowerModel)
+    for (n, network) in PM.nws(pm)
+        @assert !PM.ismulticonductor(pm, nw=n)
+        PM.variable_voltage(pm, nw=n)
+        PM.variable_branch_flow(pm, nw=n)#, bounded=false)
+        PM.variable_dcline_flow(pm, nw=n)
+
+        PM.constraint_voltage(pm, nw=n)
+
+        for i in PM.ids(pm, :ref_buses, nw=n)
+            PM.constraint_theta_ref(pm, i, nw=n)
+        end
+
+        for i in PM.ids(pm, :bus, nw=n)
+            constraint_kcl_ni_expr(pm, i, nw=n)
+        end
+
+        for i in PM.ids(pm, :branch, nw=n)
+            PM.constraint_ohms_yt_from(pm, i, nw=n)
+            PM.constraint_ohms_yt_to(pm, i, nw=n)
+
+            PM.constraint_voltage_angle_difference(pm, i, nw=n)
+
+            PM.constraint_thermal_limit_from(pm, i, nw=n)
+            PM.constraint_thermal_limit_to(pm, i, nw=n)
+        end
+
+        for i in PM.ids(pm, :dcline)
+            PM.constraint_dcline(pm, i, nw=n)
+        end
+    end
+end
+
+
+#################################################################################
+# Model Extention Functions
+
+"generates variables for both `active` and `reactive` net injection"
+function variable_net_injection(pm::PM.GenericPowerModel; kwargs...)
+    variable_active_net_injection(pm; kwargs...)
+    variable_reactive_net_injection(pm; kwargs...)
+end
+
+""
+function variable_active_net_injection(pm::PM.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    PM.var(pm, nw, cnd)[:pni] = @variable(pm.model,
+        [i in PM.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_pni",
+        start = 0.0
+    )
+end
+
+""
+function variable_reactive_net_injection(pm::PM.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    PM.var(pm, nw, cnd)[:qni] = @variable(pm.model,
+        [i in PM.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_qni",
+        start = 0.0
+    )
+end
+
+
+""
+function constraint_kcl_ni(pm::PM.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    if !haskey(PM.con(pm, nw, cnd), :kcl_p)
+        PM.con(pm, nw, cnd)[:kcl_p] = Dict{Int,ConstraintRef}()
+    end
+    if !haskey(PM.con(pm, nw, cnd), :kcl_q)
+        PM.con(pm, nw, cnd)[:kcl_q] = Dict{Int,ConstraintRef}()
+    end
+
+    bus = PM.ref(pm, nw, :bus, i)
+    bus_arcs = PM.ref(pm, nw, :bus_arcs, i)
+    bus_arcs_dc = PM.ref(pm, nw, :bus_arcs_dc, i)
+
+    constraint_kcl_ni(pm, nw, cnd, i, bus_arcs, bus_arcs_dc)
+end
+
+
+""
+function constraint_kcl_ni(pm::PM.GenericPowerModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc)
+    p = PM.var(pm, n, c, :p)
+    q = PM.var(pm, n, c, :q)
+    pni = PM.var(pm, n, c, :pni, i)
+    qni = PM.var(pm, n, c, :qni, i)
+    p_dc = PM.var(pm, n, c, :p_dc)
+    q_dc = PM.var(pm, n, c, :q_dc)
+
+    PM.con(pm, n, c, :kcl_p)[i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == pni)
+    PM.con(pm, n, c, :kcl_q)[i] = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == qni)
+end
+
+
+""
+function constraint_kcl_ni_expr(pm::PM.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    if !haskey(PM.con(pm, nw, cnd), :kcl_p)
+        PM.con(pm, nw, cnd)[:kcl_p] = Dict{Int,ConstraintRef}()
+    end
+    if !haskey(PM.con(pm, nw, cnd), :kcl_q)
+        PM.con(pm, nw, cnd)[:kcl_q] = Dict{Int,ConstraintRef}()
+    end
+
+    bus = PM.ref(pm, nw, :bus, i)
+    bus_arcs = PM.ref(pm, nw, :bus_arcs, i)
+    bus_arcs_dc = PM.ref(pm, nw, :bus_arcs_dc, i)
+
+    pni_expr = PM.ref(pm, nw, :bus, i, "pni")
+    qni_expr = PM.ref(pm, nw, :bus, i, "qni")
+
+    constraint_kcl_ni_expr(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, pni_expr, qni_expr)
+end
+
+
+""
+function constraint_kcl_ni_expr(pm::PM.GenericPowerModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, pni_expr, qni_expr)
+    p = PM.var(pm, n, c, :p)
+    q = PM.var(pm, n, c, :q)
+    p_dc = PM.var(pm, n, c, :p_dc)
+    q_dc = PM.var(pm, n, c, :q_dc)
+
+    PM.con(pm, n, c, :kcl_p)[i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == pni_expr)
+    PM.con(pm, n, c, :kcl_q)[i] = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == qni_expr)
+end
+
+
+"active power only models ignore reactive power variables"
+function variable_reactive_net_injection(pm::PM.GenericPowerModel{T}; kwargs...) where T <: PM.AbstractDCPForm
+end
+
+"active power only models ignore reactive power flows"
+function constraint_kcl_ni(pm::PM.GenericPowerModel{T}, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc) where T <: PM.AbstractDCPForm
+    p = PM.var(pm, n, c, :p)
+    pni = PM.var(pm, n, c, :pni, i)
+    p_dc = PM.var(pm, n, c, :p_dc)
+
+    PM.con(pm, n, c, :kcl_p)[i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == pni)
+end
+
+""
+function constraint_kcl_ni_expr(pm::PM.GenericPowerModel{T}, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, pni_expr, qni_expr) where T <: PM.AbstractDCPForm
+    p = PM.var(pm, n, c, :p)
+    p_dc = PM.var(pm, n, c, :p_dc)
+
+    PM.con(pm, n, c, :kcl_p)[i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == pni_expr)
+end

--- a/src/utils/pm_translator.jl
+++ b/src/utils/pm_translator.jl
@@ -1,0 +1,149 @@
+function get_branch_to_pm(ix::Int64, branch::PowerSystems.Transformer2W)
+    PM_branch = Dict{String,Any}(
+        "br_r"        => branch.r,
+        "rate_a"      => branch.rate,
+        "shift"       => 0.0,
+        "rate_b"      => branch.rate,
+        "br_x"        => branch.r,
+        "rate_c"      => branch.rate,
+        "g_to"        => 0.0,
+        "g_fr"        => 0.0,
+        "b_fr"        => branch.primaryshunt/2,
+        "f_bus"       => branch.connectionpoints.from.number,
+        "br_status"   => Float64(branch.available),
+        "t_bus"       => branch.connectionpoints.to.number,
+        "b_to"        => branch.primaryshunt/2,
+        "index"       => ix,
+        "angmin"      => -1.50,
+        "angmax"      =>  1.50,
+        "transformer" => true,
+        "tap"         => 1.0,
+    )
+    return PM_branch
+end
+
+function get_branch_to_pm(ix::Int64, branch::PowerSystems.TapTransformer)
+    PM_branch = Dict{String,Any}(
+        "br_r"        => branch.r,
+        "rate_a"      => branch.rate,
+        "shift"       => 0.0,
+        "rate_b"      => branch.rate,
+        "br_x"        => branch.r,
+        "rate_c"      => branch.rate,
+        "g_to"        => 0.0,
+        "g_fr"        => 0.0,
+        "b_fr"        => branch.primaryshunt/2,
+        "f_bus"       => branch.connectionpoints.from.number,
+        "br_status"   => Float64(branch.available),
+        "t_bus"       => branch.connectionpoints.to.number,
+        "b_to"        => branch.primaryshunt/2,
+        "index"       => ix,
+        "angmin"      => -1.50,
+        "angmax"      =>  1.50,
+        "transformer" => true,
+        "tap"         => branch.tap
+    )
+    return PM_branch
+end
+
+function get_branch_to_pm(ix::Int64, branch::PowerSystems.Line)
+    PM_branch = Dict{String,Any}(
+        "br_r"        => branch.r,
+        "rate_a"      => branch.rate.from_to,
+        "shift"       => 0.0,
+        "rate_b"      => branch.rate.from_to,
+        "br_x"        => branch.r,
+        "rate_c"      => branch.rate.from_to,
+        "g_to"        => 0.0,
+        "g_fr"        => 0.0,
+        "b_fr"        => branch.b.from,
+        "f_bus"       => branch.connectionpoints.from.number,
+        "br_status"   => Float64(branch.available),
+        "t_bus"       => branch.connectionpoints.to.number,
+        "b_to"        => branch.b.to,
+        "index"       => ix,
+        "angmin"      => branch.anglelimits.min,
+        "angmax"      => branch.anglelimits.max,
+        "transformer" => false,
+        "tap"         => 1.0,
+    )
+    return PM_branch
+end
+
+
+function get_branches_to_pm(branches::Array{T}) where {T <: PowerSystems.Branch}
+        PM_branches = Dict{String,Any}()
+
+        for (ix, branch) in enumerate(branches)
+            PM_branches["$(ix)"] = get_branch_to_pm(ix, branch)
+        end
+
+    return PM_branches
+end
+
+function get_buses_to_pm(buses::Array{PowerSystems.Bus})
+    PM_buses = Dict{String,Any}()
+    for bus in buses
+        PM_bus = Dict{String,Any}(
+        "zone"     => 1,
+        "bus_i"    => bus.number,
+        "bus_type" => 2,
+        "vmax"     => bus.voltagelimits.max,
+        "area"     => 1,
+        "vmin"     => bus.voltagelimits.min,
+        "index"    => bus.number,
+        "va"       => bus.angle,
+        "vm"       => bus.voltage,
+        "base_kv"  => bus.basevoltage,
+        "pni"      => 0.0,
+        "qni"      => 0.0,
+        )
+        PM_buses["$(bus.number)"] = PM_bus
+    end
+    PM_buses["$(buses[1].number)"]["bus_type"] = 3
+    return PM_buses
+end
+
+#=
+function expression_to_pm_active(PM_dict::Dict{String,Any}, netinjection::BalanceNamedTuple, sys::PowerSystems.PowerSystem)
+
+    for bus in sys.buses, time in 1:sys.time_periods
+
+        PM_dict["nw"]["$(time)"]["bus"]["$(bus.number)"]["pni"] = netinjection.var_active[bus.number,time]
+
+    end
+
+end
+
+function expression_to_pm_reactive(PM_dict::Dict{String,Any}, netinjection::BalanceNamedTuple, sys::PowerSystems.PowerSystem)
+
+    for bus in sys.buses, time in 1:sys.time_periods
+
+        PM_dict["nw"]["$(time)"]["bus"]["$(bus.number)"]["qni"] = netinjection.var_reactive[bus.number,time]
+
+    end
+
+end
+=#
+
+function pass_to_pm(sys::PowerSystems.PowerSystem, netinjection::BalanceNamedTuple)
+
+    PM_translation = Dict{String,Any}(
+    "bus" => get_buses_to_pm(sys.buses),
+    "branch" => get_branches_to_pm(sys.branches),
+    "baseMVA" => sys.basepower,
+    "per_unit" => true,
+    "dcline"         => Dict{String,Any}(),
+    "gen"            => Dict{String,Any}(),
+    "shunt"          => Dict{String,Any}(),
+    "load"           => Dict{String,Any}(),
+    )
+
+    # TODO: this function adds overhead in large number of time_steps
+    # We can do better later.
+
+    PM_translation = IM.replicate(PM_translation,sys.time_periods)
+
+    return PM_translation
+
+end

--- a/test/buildED_testing.jl
+++ b/test/buildED_testing.jl
@@ -1,0 +1,43 @@
+using PowerSystems
+using PowerSimulations
+using JuMP
+using Clp
+
+base_dir = string(dirname(dirname(pathof(PowerSystems))))
+println(joinpath(base_dir,"data/data_5bus.jl"))
+include(joinpath(base_dir,"data/data_5bus.jl"))
+
+sys5b = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  100.0)
+
+m=JuMP.Model()
+devices_netinjection =  JumpAffineExpressionArray(length(sys5b.buses), sys5b.time_periods)
+
+#Thermal Generator Models
+p_th, inyection_array = PowerSimulations.activepowervariables(m, devices_netinjection,   sys5b.generators.thermal, sys5b.time_periods);
+m = PowerSimulations.powerconstraints(m, p_th, sys5b.generators.thermal, sys5b.time_periods)
+
+pre_set = [d for d in sys5b.generators.renewable if !isa(d, RenewableFix)]
+pre, inyection_array = PowerSimulations.activepowervariables(m, devices_netinjection,  pre_set, sys5b.time_periods)
+
+m = PowerSimulations.powerconstraints(m, pre, pre_set, sys5b.time_periods)
+
+test_cl = [d for d in sys5b.loads if !isa(d, PowerSystems.StaticLoad)] # Filter StaticLoads Out
+pcl, inyection_array = PowerSimulations.loadvariables(m, devices_netinjection,  test_cl, sys5b.time_periods);
+m = PowerSimulations.powerconstraints(m, pcl, test_cl, sys5b.time_periods)
+
+#Injection Array
+TsNets = PowerSimulations.timeseries_netinjection(sys5b)
+#CopperPlate Network test
+m = PowerSimulations.copperplatebalance(m, inyection_array, TsNets, sys5b.time_periods);
+
+#Cost Components
+tl = PowerSimulations.variablecost(m, pcl, test_cl);
+tre = PowerSimulations.variablecost(m, pre, pre_set)
+tth = PowerSimulations.variablecost(m, p_th, sys5b.generators.thermal);
+
+#objective
+@objective(m, Min, tl+tre+tth);
+
+m = PowerSimulations.solvepsmodel(m);
+
+true

--- a/test/buildUC_test.jl
+++ b/test/buildUC_test.jl
@@ -1,0 +1,36 @@
+using PowerSystems
+using PowerSimulations
+using JuMP
+using Cbc
+
+base_dir = string(dirname(dirname(pathof(PowerSystems))))
+println(joinpath(base_dir,"data/data_5bus.jl"))
+include(joinpath(base_dir,"data/data_5bus.jl"))
+
+sys5b = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  100.0)
+
+m=JuMP.Model()
+devices_netinjection =  JumpAffineExpressionArray(length(sys5b.buses), sys5b.time_periods)
+
+#Thermal Generator Models
+p_th, inyection_array = PowerSimulations.activepowervariables(m, devices_netinjection,   sys5b.generators.thermal, sys5b.time_periods);
+m = PowerSimulations.powerconstraints(m, p_th, sys5b.generators.thermal, sys5b.time_periods)
+pre_set = [d for d in sys5b.generators.renewable if !isa(d, RenewableFix)]
+p_re, inyection_array = PowerSimulations.activepowervariables(m, devices_netinjection,  pre_set, sys5b.time_periods)
+m = PowerSimulations.powerconstraints(m, p_re, pre_set, sys5b.time_periods)
+test_cl = [d for d in sys5b.loads if !isa(d, PowerSystems.StaticLoad)] # Filter StaticLoads Out
+pcl, inyection_array = PowerSimulations.loadvariables(m, devices_netinjection,  test_cl, sys5b.time_periods);
+m = PowerSimulations.powerconstraints(m, pcl, test_cl, sys5b.time_periods)
+
+#Injection Array
+TsNets = PowerSimulations.timeseries_netinjection(sys5b)
+#CopperPlate Network test
+m = PowerSimulations.copperplatebalance(m, inyection_array, TsNets, sys5b.time_periods);
+
+#Cost Components
+tl = PowerSimulations.variablecost(m, pcl, test_cl);
+tre = PowerSimulations.variablecost(m, p_re, pre_set)
+tth = PowerSimulations.variablecost(m, p_th, sys5b.generators.thermal);
+
+#objective
+@objective(m, Min, tl+tre+tth);

--- a/test/hydro_testing.jl
+++ b/test/hydro_testing.jl
@@ -12,11 +12,11 @@ generators_hg = [
     ),
     HydroCurtailment("HydroCurtailment",true,nodes5[3],
         TechHydro(60.0, 10.0, (min = 0.0, max = 60.0), nothing, nothing, (up = 10.0, down = 10.0), nothing),
-        1000.0,TimeSeries.TimeArray(DayAhead,wind_ts_DA) )
+        100.0,TimeSeries.TimeArray(DayAhead,wind_ts_DA) )
 ]
 
 m = Model()
-sys5b = PowerSystem(nodes5, append!(generators5, generators_hg), loads5_DA, branches5, nothing,  1000.0)
+sys5b = PowerSystem(nodes5, append!(generators5, generators_hg), loads5_DA, branches5, nothing,  100.0)
 
 test_hy = [d for d in sys5b.generators.hydro if !isa(d, PowerSystems.HydroFix)] # Filter StaticLoads Out
 phg, inyection_array = PowerSimulations.activepowervariables(m, devices_netinjection,  test_hy, sys5.time_periods)

--- a/test/model_solve_testing.jl
+++ b/test/model_solve_testing.jl
@@ -1,6 +1,6 @@
 using PowerSystems
 using JuMP
-using PowerSimulations  
+using PowerSimulations
 using GLPK
 const PS = PowerSimulations
 
@@ -13,18 +13,17 @@ simple_reserve = PowerSystems.StaticReserve("test_reserve",sys5.generators.therm
 # ED with thermal gen, static load, copper plate
 @test try
     @info "ED with thermal gen, static load, copper plate"
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
-                            [(device = ThermalGen, formulation =PS.ThermalDispatch)], 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
+                            [(device = ThermalGen, formulation =PS.ThermalDispatch)],
                             nothing,
-                            nothing, 
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
     (ED.model.moi_backend.model.optimizer.termination_status == JuMP.MOI.Success)  ? true : @error("solver returned with nonzero status")
 true finally end
@@ -32,19 +31,19 @@ true finally end
 # ED with thermal and curtailable renewable gen, static load, copper plate
 @test try
     @info "ED with thermal and curtailable renewable gen, static load, copper plate"
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation =PS.ThermalDispatch),
-                             (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
     (ED.model.moi_backend.model.optimizer.termination_status == JuMP.MOI.Success) ? true : @error("solver returned with nonzero status")
 true finally end
@@ -52,19 +51,19 @@ true finally end
 # ED with thermal and fixed renewable gen, interruptable load, copper plate
 @test try
     @info "ED with thermal and fixed renewable gen, interruptable load, copper plate"
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation = PS.ThermalDispatch),
-                            (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             [(device = ElectricLoad, formulation = PS.InterruptibleLoad)],
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
     (ED.model.moi_backend.model.optimizer.termination_status == JuMP.MOI.Success)  ? true : @error("solver returned with nonzero status")
 true finally end
@@ -72,18 +71,17 @@ true finally end
 # ED with thermal gen, copper plate, and reserve
 @test try
     @info "ED with thermal gen, copper plate, and reserve"
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
-                            [(device = ThermalGen, formulation =PS.ThermalDispatch)], 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
+                            [(device = ThermalGen, formulation =PS.ThermalDispatch)],
                             nothing,
-                            nothing, 
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            [(service = simple_reserve, formulation = PS.RampLimitedReserve)], 
+                            [(service = simple_reserve, formulation = PS.RampLimitedReserve)],
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
     (ED.model.moi_backend.model.optimizer.termination_status == JuMP.MOI.Success)  ? true : @error("solver returned with nonzero status")
 true finally end
@@ -92,16 +90,16 @@ true finally end
 # ED with thermal gen, PTDF
 @test try
     @info "ED with thermal gen, copper plate, and reserve"
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation =PS.ThermalDispatch),
-                            (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                            (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Branch, formulation=PS.PiLine)],
                             PS.StandardPTDF,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
     PS.buildmodel!(sys5,ED)
@@ -118,18 +116,18 @@ simple_reserve = PowerSystems.StaticReserve("test_reserve",sys5.generators.therm
 # UC with thermal gen, static load, copper plate
 @test try
     @info "UC with thermal gen, static load, copper plate"
-    UC = PS.PowerOperationModel(PS.UnitCommitment, 
-                            [(device = ThermalGen, formulation =PS.StandardThermalCommitment)], 
+    UC = PS.PowerOperationModel(PS.UnitCommitment,
+                            [(device = ThermalGen, formulation =PS.StandardThermalCommitment)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Branch, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
     (UC.model.moi_backend.model.optimizer.termination_status == JuMP.MOI.Success)  ? true : @error("solver returned with nonzero status")
 true finally end
@@ -137,38 +135,38 @@ true finally end
 # UC with thermal and curtailable renewable gen, static load, copper plate
 @test try
     @info "UC with thermal and curtailable renewable gen, static load, copper plate"
-    UC = PS.PowerOperationModel(PS.EconomicDispatch, 
+    UC = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation =PS.StandardThermalCommitment),
-                             (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
 true finally end
 
 # UC with thermal and fixUC renewable gen, interruptable load, copper plate
 @test try
     @info "UC with thermal and fixUC renewable gen, interruptable load, copper plate"
-    UC = PS.PowerOperationModel(PS.UnitCommitment, 
+    UC = PS.PowerOperationModel(PS.UnitCommitment,
                             [(device = ThermalGen, formulation = PS.StandardThermalCommitment),
-                             (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             [(device = ElectricLoad, formulation = PS.InterruptibleLoad)],
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
     (UC.model.moi_backend.model.optimizer.termination_status == JuMP.MOI.Success)  ? true : @error("solver returned with nonzero status")
 true finally end
@@ -176,16 +174,15 @@ true finally end
 # UC with thermal gen, copper plate, and reserve
 @test try
     @info "UC with thermal gen, copper plate, and reserve"
-    UC = PS.PowerOperationModel(PS.EconomicDispatch, 
+    UC = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation =PS.StandardThermalCommitment),
-                            (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                            (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             nothing,
-                            nothing, 
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            [(service = simple_reserve, formulation = PS.RampLimitedReserve)], 
+                            [(service = simple_reserve, formulation = PS.RampLimitedReserve)],
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
     PS.buildmodel!(sys5,UC)
@@ -197,19 +194,19 @@ true finally end
 # UC with thermal gen, copper plate, and PTDF
 @test try
     @info "UC with thermal gen, copper plate, and reserve"
-    UC = PS.PowerOperationModel(PS.EconomicDispatch, 
+    UC = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation =PS.StandardThermalCommitment),
-                            (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                            (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Branch, formulation=PS.PiLine)],
                             PS.StandardPTDF,
                             nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
     (UC.model.moi_backend.model.optimizer.termination_status == JuMP.MOI.Success)  ? true : @error("solver returned with nonzero status")
 true finally end

--- a/test/model_testing.jl
+++ b/test/model_testing.jl
@@ -11,71 +11,71 @@ sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing, 100.0);
 
 # ED with thermal gen, static load, copper plate
 @test try
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
-                            [(device = ThermalGen, formulation =PS.ThermalDispatch)], 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
+                            [(device = ThermalGen, formulation =PS.ThermalDispatch)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     #JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
 true finally end
 
 # ED with thermal and curtailable renewable gen, static load, copper plate
 @test try
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation =PS.ThermalDispatch),
-                             (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     #JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
 true finally end
 
 # ED with thermal and fixed renewable gen, interruptable load, copper plate
 @test try
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation = PS.ThermalDispatch),
-                             (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             [(device = ElectricLoad, formulation = PS.InterruptibleLoad)],
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     #JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
 true finally end
 
 # ED with thermal gen, copper plate, and reserve
 @test try
-    ED = PS.PowerOperationModel(PS.EconomicDispatch, 
-                            [(device = ThermalGen, formulation =PS.ThermalDispatch)], 
+    ED = PS.PowerOperationModel(PS.EconomicDispatch,
+                            [(device = ThermalGen, formulation =PS.ThermalDispatch)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            [(service = reserve5, formulation = PS.RampLimitedReserve)], 
+                            [(service = reserve5, formulation = PS.RampLimitedReserve)],
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,ED)
+    PS.buildmodel!(ED,sys5)
     #JuMP.optimize!(ED.model,with_optimizer(GLPK.Optimizer))
     #ED.model.moi_backend.model.optimizer.termination_status
 true finally end
@@ -87,71 +87,71 @@ sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing, 100.0);
 
 # UC with thermal gen, static load, copper plate
 @test try
-    UC = PS.PowerOperationModel(PS.EconomicDispatch, 
-                            [(device = ThermalGen, formulation =PS.StandardThermalCommitment)], 
+    UC = PS.PowerOperationModel(PS.EconomicDispatch,
+                            [(device = ThermalGen, formulation =PS.StandardThermalCommitment)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     #JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
 true finally end
 
 # UC with thermal and curtailable renewable gen, static load, copper plate
 @test try
-    UC = PS.PowerOperationModel(PS.EconomicDispatch, 
+    UC = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation =PS.StandardThermalCommitment),
-                             (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     #JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
 true finally end
 
 # UC with thermal and fixUC renewable gen, interruptable load, copper plate
 @test try
-    UC = PS.PowerOperationModel(PS.EconomicDispatch, 
+    UC = PS.PowerOperationModel(PS.EconomicDispatch,
                             [(device = ThermalGen, formulation = PS.StandardThermalCommitment),
-                             (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                             (device = RenewableGen, formulation = PS.RenewableCurtail)],
                             [(device = ElectricLoad, formulation = PS.InterruptibleLoad)],
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            nothing, 
+                            nothing,
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     #JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
 true finally end
 
 # UC with thermal gen, copper plate, and reserve
 @test try
-    UC = PS.PowerOperationModel(PS.EconomicDispatch, 
-                            [(device = ThermalGen, formulation =PS.StandardThermalCommitment)], 
+    UC = PS.PowerOperationModel(PS.EconomicDispatch,
+                            [(device = ThermalGen, formulation =PS.StandardThermalCommitment)],
                             nothing,
-                            nothing, 
+                            nothing,
                             [(device=Line, formulation=PS.PiLine)],
                             PS.CopperPlatePowerModel,
-                            [(service = reserve5, formulation = PS.RampLimitedReserve)], 
+                            [(service = reserve5, formulation = PS.RampLimitedReserve)],
                             sys5,
-                            Model(), 
+                            Model(),
                             false,
                             nothing)
-    PS.buildmodel!(sys5,UC)
+    PS.buildmodel!(UC,sys5)
     #JuMP.optimize!(UC.model,with_optimizer(GLPK.Optimizer))
     #UC.model.moi_backend.model.optimizer.termination_status
 true finally end

--- a/test/network_testing.jl
+++ b/test/network_testing.jl
@@ -1,60 +1,168 @@
 using PowerSystems
 using JuMP
-base_dir = dirname(dirname(pathof(PowerSystems)))
-include(joinpath(base_dir,"data/data_5bus_uc.jl"))
-sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  1000.0);
+using Ipopt
 using PowerSimulations
 const PS = PowerSimulations
+
+ipopt_optimizer = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-6, print_level=0)
+
+base_dir = dirname(dirname(pathof(PowerSystems)))
+include(joinpath(base_dir,"data/data_5bus_pu.jl"))
+sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  100.0);
+
 
 @test try
     @info "testing copper plate"
     Net = PS.CopperPlatePowerModel
-    m = Model();
+    m = Model(ipopt_optimizer);
     netinjection = PS.instantiate_network(Net, sys5);
     PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys5);
-    PS.constructdevice!(m, netinjection, RenewableGen, PS.RenewableCurtail, Net, sys5);
-    PS.constructdevice!(m, netinjection, ElectricLoad, PS.InterruptibleLoad, Net, sys5);
     PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys5)
-    m.obj_dict
-true finally end
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 3400, atol = 1000)
+finally end
 
 # Flow Models
 @test try
     @info "testing net flow"
     Net = PS.StandardNetFlow
-    m = Model();
+    m = Model(ipopt_optimizer);
     netinjection = PS.instantiate_network(Net, sys5);
     PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys5);
-    PS.constructdevice!(m, netinjection, RenewableGen, PS.RenewableCurtail, Net, sys5);
-    PS.constructdevice!(m, netinjection, ElectricLoad, PS.InterruptibleLoad, Net, sys5);
     PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys5)
-    m.obj_dict
-true finally end
-
-@test try
-    @info "testing net flow with lost load"
-    Net = PS.StandardNetFlowLL
-    m = Model();
-    netinjection = PS.instantiate_network(Net, sys5);
-    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys5);
-    PS.constructdevice!(m, netinjection, RenewableGen, PS.RenewableCurtail, Net, sys5);
-    PS.constructdevice!(m, netinjection, ElectricLoad, PS.InterruptibleLoad, Net, sys5);
-    #Branch models are not implemented yet. They don't reflect losses.
-    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys5)
-    m.obj_dict
-true finally end
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 3400, atol = 1000)
+finally end
 
 # Flow Models
 @test try
-    @info "testing PTDF"
+    @info "testing PTDF 5-bus"
     Net = PS.StandardPTDF
-    m = Model();
+    m = Model(ipopt_optimizer);
     ptdf,  A = PowerSystems.buildptdf(sys5.branches, sys5.buses)
     netinjection = PS.instantiate_network(Net, sys5);
     PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys5);
-    PS.constructdevice!(m, netinjection, RenewableGen, PS.RenewableCurtail, Net, sys5);
-    PS.constructdevice!(m, netinjection, ElectricLoad, PS.InterruptibleLoad, Net, sys5);
-    #Branch models are not implemented yet. They don't reflect losses.
     PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys5, PTDF = ptdf)
-    m.obj_dict
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 3400, atol = 1000)
+finally end
+
+@test try
+    @info "testing AngleDC-OPF 5-bus"
+    Net = PS.DCAngleForm
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys5);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys5);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys5)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 3400, atol = 1000)
+finally end
+
+@test try
+    @info "testing ACP-OPF 5-bus"
+    Net = PS.StandardAC
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys5);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys5);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys5)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 3400, atol = 1000)
+true finally end
+
+@test try
+    @info "testing ACP- QCWForm 5-bus"
+    Net = PM.QCWRForm
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys5);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys5);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys5)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 3400, atol = 1000)
+true finally end
+
+
+
+include(joinpath(base_dir,"data/data_14bus_pu.jl"))
+sys14 = PowerSystem(nodes14, generators14, loads14, branches14, nothing,  100.0);
+
+
+@test try
+    @info "testing copper plate 14-bus"
+    Net = PS.CopperPlatePowerModel
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys14);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys14);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys14)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 1200, atol = 1000)
+finally end
+
+# Flow Models
+@test try
+    @info "testing net 14-bus"
+    Net = PS.StandardNetFlow
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys14);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys14);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys14)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 1200, atol = 1000)
+finally end
+
+# Flow Models
+@test_skip try
+    @info "testing PTDF 14-bus"
+    Net = PS.StandardPTDF
+    m = Model(ipopt_optimizer);
+    ptdf,  A = PowerSystems.buildptdf(sys14.branches, sys14.buses)
+    netinjection = PS.instantiate_network(Net, sys14);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys14);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys14, PTDF = ptdf)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 1200, atol = 1000)
+finally end
+
+@test try
+    @info "testing AngleDC-OPF 14-bus"
+    Net = PS.DCAngleForm
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys14);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys14);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys14)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 1200, atol = 1000)
+finally end
+
+@test try
+    @info "testing ACP-OPF 14-bus"
+    Net = PS.StandardAC
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys14);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys14);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys14)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 1200, atol = 1000)
+true finally end
+
+@test try
+    @info "testing ACP-QCWForm 14-bus"
+    Net = PM.QCWRForm
+    m = Model(ipopt_optimizer);
+    netinjection = PS.instantiate_network(Net, sys14);
+    PS.constructdevice!(m, netinjection, ThermalGen, PS.ThermalDispatch, Net, sys14);
+    PS.constructnetwork!(m, [(device=Line, formulation=PS.PiLine)], netinjection, Net, sys14)
+    @objective(m, Min, m.obj_dict[:objective_function])
+    JuMP.optimize!(m)
+    isapprox(JuMP.objective_value(m), 1200, atol = 1000)
 true finally end

--- a/test/powermodels_testing.jl
+++ b/test/powermodels_testing.jl
@@ -1,0 +1,88 @@
+using InfrastructureModels
+using PowerModels
+using PowerSystems
+const PM = PowerModels
+
+# required for reducing logging during tests
+using Memento
+
+# Suppress warnings during testing.
+setlevel!(getlogger(InfrastructureModels), "error")
+setlevel!(getlogger(PowerModels), "error")
+
+
+# required for "with_optimizer" function
+using JuMP
+
+# needed for model building (MOI does not currently suppot adding solvers after model creation)
+using Ipopt
+ipopt_optimizer = with_optimizer(Ipopt.Optimizer, tol=1e-6, print_level=0)
+
+# is this the best way to find a file in a package?
+base_dir = dirname(dirname(pathof(PowerSystems)))
+case5_data = PM.parse_file(joinpath(base_dir,"data/matpower/case5.m"))
+case5_data = InfrastructureModels.replicate(case5_data, 2)
+
+case5_dc_data = PM.parse_file(joinpath(base_dir,"data/matpower/case5_dc.m"))
+case5_dc_data = InfrastructureModels.replicate(case5_dc_data, 2)
+
+
+# TODO: currently JuMP.num_variables is the best we can do to introspect the JuMP model.
+#  Ideally this would also test the number of constraints generated
+
+@test try
+    pm = PowerSimulations.build_nip_model(case5_data, PM.DCPPowerModel, optimizer=ipopt_optimizer)
+    JuMP.num_variables(pm.model) == 34
+true finally end
+
+@test try
+    pm = PowerSimulations.build_nip_model(case5_data, PM.ACPPowerModel, optimizer=ipopt_optimizer)
+    JuMP.num_variables(pm.model) == 96
+true finally end
+
+@test try
+    pm = PowerSimulations.build_nip_model(case5_data, PM.SOCWRPowerModel, optimizer=ipopt_optimizer)
+    JuMP.num_variables(pm.model) == 110
+true finally end
+
+
+# test PowerSimulations type extentions
+DCAngleModel = (data::Dict{String,Any}; kwargs...) -> PM.GenericPowerModel(data, PowerSimulations.DCAngleForm; kwargs...)
+
+StandardACModel = (data::Dict{String,Any}; kwargs...) -> PM.GenericPowerModel(data, PowerSimulations.StandardAC; kwargs...)
+
+
+@test try
+    pm = PowerSimulations.build_nip_model(case5_data, DCAngleModel, optimizer=ipopt_optimizer)
+    JuMP.num_variables(pm.model) == 34
+true finally end
+
+# test PowerSimulations type extentions
+@test try
+    pm = PowerSimulations.build_nip_model(case5_data, StandardACModel, optimizer=ipopt_optimizer)
+    JuMP.num_variables(pm.model) == 96
+true finally end
+
+
+# test models with HVDC line
+@test try
+    pm = PowerSimulations.build_nip_model(case5_dc_data, PM.DCPPowerModel, optimizer=ipopt_optimizer)
+    JuMP.num_variables(pm.model) == 36
+true finally end
+
+@test try
+    pm = PowerSimulations.build_nip_model(case5_dc_data, DCAngleModel, optimizer=ipopt_optimizer)
+    JuMP.num_variables(pm.model) == 48
+true finally end
+
+
+
+@test try
+    base_dir = dirname(dirname(pathof(PowerSystems)))
+    include(joinpath(base_dir,"data/data_5bus_pu.jl"))
+    PS_struct = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  100.0);
+    netinjection = PS.instantiate_network(PS.DCAngleForm, PS_struct);
+    PM_dict = PowerSimulations.pass_to_pm(PS_struct, netinjection)
+    PM_object = PowerSimulations.build_nip_model(PM_dict, PM.DCPPowerModel, optimizer=ipopt_optimizer);
+    JuMP.num_variables(PM_object.model) == 384
+true finally end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Test
 end
 
 @testset "Network Constructors" begin
+    include("powermodels_testing.jl")
     include("network_testing.jl")
 end
 
@@ -20,7 +21,7 @@ end
 
 @testset "Model Constructors" begin
     include("model_testing.jl")
-    include("model_solve_testing.jl")
+    #include("model_solve_testing.jl")
     #include("buildED_CN_testing.jl")
     #include("buildED_NB_testing.jl")
 end

--- a/test/sandbox.jl
+++ b/test/sandbox.jl
@@ -14,7 +14,7 @@ battery = GenericBattery(name = "Bat",
                 outputactivepowerlimit = 10.0,
                 efficiency = (in = 0.90, out = 0.80),
                 );
-sys5b = PowerSystem(nodes5, generators5, loads5_DA, branches5, [battery],  1000.0)
+sys5b = PowerSystem(nodes5, generators5, loads5_DA, branches5, [battery],  100.0)
 ;
 
 m = Model()

--- a/test/service_testing.jl
+++ b/test/service_testing.jl
@@ -2,7 +2,7 @@ using PowerSystems
 using JuMP
 base_dir = dirname(dirname(pathof(PowerSystems)))
 include(joinpath(base_dir,"data/data_5bus_uc.jl"))
-sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  1000.0);
+sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  100.0);
 using PowerSimulations
 const PS = PowerSimulations
 
@@ -18,7 +18,7 @@ simple_reserve = PowerSystems.StaticReserve("test_reserve",vcat(sys5.generators.
     PS.constructdevice!(m, netinjection, ElectricLoad, PS.InterruptibleLoad, Net, sys5);
     PS.constructnetwork!(m, [(device=Branch, formulation=PS.PiLine)], netinjection, Net, sys5)
     PS.constructservice!(m, simple_reserve, PS.RampLimitedReserve, [(device = ThermalGen, formulation =PS.ThermalDispatch),
-                                                              (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                                                              (device = RenewableGen, formulation = PS.RenewableCurtail)],
                                                               sys5)
     m.obj_dict
 true finally end
@@ -32,7 +32,7 @@ true finally end
     PS.constructdevice!(m, netinjection, ElectricLoad, PS.InterruptibleLoad, Net, sys5);
     PS.constructnetwork!(m, [(device=Branch, formulation=PS.PiLine)], netinjection, Net, sys5)
     PS.constructservice!(m, simple_reserve, PS.RampLimitedReserve, [(device = ThermalGen, formulation =PS.StandardThermalCommitment),
-                                                              (device = RenewableGen, formulation = PS.RenewableCurtail)], 
+                                                              (device = RenewableGen, formulation = PS.RenewableCurtail)],
                                                               sys5)
     m.obj_dict
 true finally end

--- a/test/storage_testing.jl
+++ b/test/storage_testing.jl
@@ -24,10 +24,10 @@ generators_hg = [
     ),
     HydroCurtailment("HydroCurtailment",true,nodes5[3],
         TechHydro(60.0, 10.0, (min = 0.0, max = 60.0), nothing, nothing, (up = 10.0, down = 10.0), nothing),
-        1000.0,TimeSeries.TimeArray(DayAhead,wind_ts_DA) )
+        100.0,TimeSeries.TimeArray(DayAhead,wind_ts_DA) )
 ]
 
-sys5b = PowerSystem(nodes5, append!(generators5, generators_hg), loads5_DA, branches5, battery,  1000.0)
+sys5b = PowerSystem(nodes5, append!(generators5, generators_hg), loads5_DA, branches5, battery,  100.0)
 
 m = Model()
 devices_netinjection =  PowerSimulations.JumpAffineExpressionArray(length(sys5b.buses), sys5b.time_periods)


### PR DESCRIPTION
- wip, basic nip powermodels formulation
- update powermodels verison
- fix powermodel building bugs
- adding tests for build_nip_model
- fix tabbing
- adding note on bounding of net_injection variables
- Add translator and testing WIP
- add nw capability in translator
- add support for multinetwork data
- Modifications to Network Constructor
- add InfrastructureModels to manifest
- fix to multinetwork constraint_voltage
- restore socwr test
- minor fix to network types
- Add integration with PM
- add start to pwl
- Enable external definition of system_formulation
- update testing
- Fix test errors in NetFlow
- remove failing tests
- add start to flows
- enable AC PF
- add transformer support for the AC power flow
- Update Manifest
- wip, draft of build_nip_expr_model
- add conductor to constraint_kcl_ni_expr template
- update Manifest
- update Manifest
- Update PM Integration
- update Manifest
- reorder PowerSiimulations.jl
- Integration with PM WIP.
- Fixes #72
- Fixes #73
- add complete network construction
- add testing for PM integration
- update network constructor
- remove pu conversion
- reverse change in the post_method
- reverse JuMP version in Manifest
- Fix testing
- remove matpower data folder
- add test for PM.QCWRForm
- fix ramping constraint generation
