### PR TITLE
Change concrete type JuMP.Model to abstract type JuMP.AbstractModel

### DIFF
--- a/src/base/simulation_routines.jl
+++ b/src/base/simulation_routines.jl
@@ -1,6 +1,6 @@
 export simulatemodel
 
-function modify_constraint(m::JuMP.Model, consname::Symbol, data::Array{Float64,2})
+function modify_constraint(m::JuMP.AbstractModel, consname::Symbol, data::Array{Float64,2})
 
     !(size(m[consmane]) == size(data)) ? @error("The data and the constraint are size inconsistent") : true
 

--- a/src/component_constructors/branch_constructor.jl
+++ b/src/component_constructors/branch_constructor.jl
@@ -1,4 +1,4 @@
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{B}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {B <: PowerSystems.Branch, D <: AbstractBranchForm, S <: AbstractFlowForm}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{B}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {B <: PowerSystems.Branch, D <: AbstractBranchForm, S <: AbstractFlowForm}
 
     flowvariables(m, system_formulation, sys.branches, sys.time_periods)
 
@@ -6,7 +6,7 @@ function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, catego
 
 end
 
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{B}, category_formulation::Type{PiLine}, system_formulation::Type{StandardPTDF}, sys::PowerSystems.PowerSystem; args...) where {B <: PowerSystems.Branch}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{B}, category_formulation::Type{PiLine}, system_formulation::Type{StandardPTDF}, sys::PowerSystems.PowerSystem; args...) where {B <: PowerSystems.Branch}
 
     PTDF = [a.second for a in args if a.first == :PTDF][1]
 

--- a/src/component_constructors/hydrogeneration_constructor.jl
+++ b/src/component_constructors/hydrogeneration_constructor.jl
@@ -2,7 +2,7 @@ struct Hydro end
 
 const curtailconstraints = PowerSimulations.powerconstraints
 
-function constructdevice!(category::Type{Hydro}, transmission::Type{CopperPlatePowerModel}, m::JuMP.Model, devices_netinjection::T, sys::PowerSystems.PowerSystem, constraints::Array{<:Function}=[powerconstraints]) where T <: JumpExpressionMatrix
+function constructdevice!(category::Type{Hydro}, transmission::Type{CopperPlatePowerModel}, m::JuMP.AbstractModel, devices_netinjection::T, sys::PowerSystems.PowerSystem, constraints::Array{<:Function}=[powerconstraints]) where T <: JumpExpressionMatrix
 
     devices = [d for d in sys.generators.hydro if (d.available == true && !isa(d, HydroFix))]
 

--- a/src/component_constructors/load_constructor.jl
+++ b/src/component_constructors/load_constructor.jl
@@ -1,4 +1,4 @@
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{L}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: PM.AbstractPowerFormulation}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{L}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: PM.AbstractPowerFormulation}
 
     dev_set = [a.second for a in args if a.first == :devices]
 
@@ -17,7 +17,7 @@ function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, catego
 end
 
 
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{L}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: AbstractACPowerModel}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{L}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: AbstractACPowerModel}
 
     dev_set = [d for d in sys.loads if (d.available == true && !isa(d,PowerSystems.StaticLoad))]
 

--- a/src/component_constructors/network_constructor.jl
+++ b/src/component_constructors/network_constructor.jl
@@ -1,10 +1,10 @@
-function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: CopperPlatePowerModel}
+function constructnetwork!(m::JuMP.AbstractModel, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: CopperPlatePowerModel}
 
     copperplatebalance(m, netinjection, sys.time_periods)
 
 end
 
-function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractFlowForm}
+function constructnetwork!(m::JuMP.AbstractModel, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractFlowForm}
 
     for category in branch_models
         constructdevice!(m, netinjection, category.device, category.formulation, system_formulation, sys; args...)
@@ -14,7 +14,7 @@ function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:devi
 
 end
 
-function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{StandardPTDF}, sys::PowerSystems.PowerSystem; args...)
+function constructnetwork!(m::JuMP.AbstractModel, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{StandardPTDF}, sys::PowerSystems.PowerSystem; args...)
     if :PTDF in keys(args)
         PTDF = args[:PTDF]
     else
@@ -34,7 +34,7 @@ function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:devi
 
 end
 
-function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractDCPowerModel}
+function constructnetwork!(m::JuMP.AbstractModel, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractDCPowerModel}
 
     #= TODO: Needs to be generalized later for other branch models not covered by PM.
     for category in branch_models
@@ -52,7 +52,7 @@ function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:devi
 
 end
 
-function constructnetwork!(m::JuMP.Model, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractACPowerModel}
+function constructnetwork!(m::JuMP.AbstractModel, branch_models::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractACPowerModel}
 
     #= TODO: Needs to be generalized later for other branch models not covered by PM.
     for category in branch_models

--- a/src/component_constructors/renewablegeneration_constructor.jl
+++ b/src/component_constructors/renewablegeneration_constructor.jl
@@ -1,4 +1,4 @@
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.RenewableGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractRenewableDispatchForm, S <: PM.AbstractPowerFormulation}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.RenewableGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractRenewableDispatchForm, S <: PM.AbstractPowerFormulation}
 
     dev_set = [a.second for a in args if a.first == :devices]
 
@@ -21,7 +21,7 @@ function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, catego
 end
 
 
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.RenewableGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractRenewableDispatchForm, S <: AbstractACPowerModel}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.RenewableGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractRenewableDispatchForm, S <: AbstractACPowerModel}
 
     dev_set = [d for d in sys.generators.renewable if (d.available == true && !isa(d, PowerSystems.RenewableFix))]
 

--- a/src/component_constructors/services_constructor.jl
+++ b/src/component_constructors/services_constructor.jl
@@ -13,7 +13,7 @@ function get_devices(sys::PowerSystems.PowerSystem,category::Type{PowerSystems.P
 end
 
 
-function constructservice!(m::JuMP.Model, service::PowerSystems.StaticReserve, category_formulation::Type{PS.RampLimitedReserve},devices::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, sys::PowerSystems.PowerSystem; args...)
+function constructservice!(m::JuMP.AbstractModel, service::PowerSystems.StaticReserve, category_formulation::Type{PS.RampLimitedReserve},devices::Array{NamedTuple{(:device, :formulation), Tuple{DataType,DataType}}}, sys::PowerSystems.PowerSystem; args...)
 
     dev_set = Array{NamedTuple{(:device,:formulation),Tuple{PowerSystems.PowerSystemDevice,DataType}}}([])
 

--- a/src/component_constructors/thermalgeneration_constructor.jl
+++ b/src/component_constructors/thermalgeneration_constructor.jl
@@ -3,7 +3,7 @@
 """
 This function creates the minimal themal dispatch formulation depending on combination of devices, device_formulation and system_formulation
 """
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractThermalDispatchForm, S <: PM.AbstractPowerFormulation}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractThermalDispatchForm, S <: PM.AbstractPowerFormulation}
 
     p_th = activepowervariables(m, sys.generators.thermal, sys.time_periods);
 
@@ -18,7 +18,7 @@ function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, catego
 end
 
 
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractThermalDispatchForm, S <: AbstractACPowerModel}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractThermalDispatchForm, S <: AbstractACPowerModel}
 
     constructdevice!(m, netinjection, category, category_formulation, PM.AbstractPowerFormulation, sys; args...)
 
@@ -31,7 +31,7 @@ function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, catego
 end
 
 
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{ThermalRampLimitDispatch}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: PM.AbstractPowerFormulation}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{ThermalRampLimitDispatch}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: PM.AbstractPowerFormulation}
 
     constructdevice!(m, netinjection, category, AbstractThermalDispatchForm, PM.AbstractPowerFormulation, sys; args...)
 
@@ -49,7 +49,7 @@ end
 """
 This function creates the minimal the minimal thermal commitment formulation
 """
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractThermalCommitmentForm, S <: AbstractDCPowerModel}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{D}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {D <: AbstractThermalCommitmentForm, S <: AbstractDCPowerModel}
 
     p_th = activepowervariables(m, sys.generators.thermal, sys.time_periods);
 
@@ -73,7 +73,7 @@ end
 """
 This function adds constraints to the minimal thermal commitment formulation
 """
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{StandardThermalCommitment}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractDCPowerModel}
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{StandardThermalCommitment}, system_formulation::Type{S}, sys::PowerSystems.PowerSystem; args...) where {S <: AbstractDCPowerModel}
 
     constructdevice!(m, netinjection, category, AbstractThermalCommitmentForm, AbstractDCPowerModel, sys; args...)
 
@@ -92,7 +92,7 @@ end
 """
 This function adds constraints to the minimal thermal commitment formulation
 """
-function constructdevice!(m::JuMP.Model, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{StandardThermalCommitment}, system_formulation::Type{CopperPlatePowerModel}, sys::PowerSystems.PowerSystem; args...)
+function constructdevice!(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, category::Type{PowerSystems.ThermalGen}, category_formulation::Type{StandardThermalCommitment}, system_formulation::Type{CopperPlatePowerModel}, sys::PowerSystems.PowerSystem; args...)
 
     constructdevice!(m, netinjection, category, category_formulation, AbstractDCPowerModel, sys; args...)
 

--- a/src/core/abstract_models.jl
+++ b/src/core/abstract_models.jl
@@ -15,7 +15,7 @@ mutable struct PowerOperationModel{ M<:AbstractOperationsModel, T<:NetworkModel,
     transmission::Type{T}
     services::S
     system::PowerSystems.PowerSystem
-    model::JuMP.Model
+    model::JuMP.AbstractModel
     dynamics::Bool
     ptdf::Union{Nothing,PTDFArray}
 end

--- a/src/device_models/branches/bus_variables.jl
+++ b/src/device_models/branches/bus_variables.jl
@@ -1,4 +1,4 @@
-function anglevariables(m::JuMP.Model, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: Union{PM.AbstractDCPForm, PM.AbstractACPForm}}
+function anglevariables(m::JuMP.AbstractModel, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: Union{PM.AbstractDCPForm, PM.AbstractACPForm}}
 
     on_set = [d.name for d in sys.buses if d.available == true]
 
@@ -8,7 +8,7 @@ function anglevariables(m::JuMP.Model, system_formulation::Type{S}, sys::PowerSy
 
 end
 
-function voltagevariables(m::JuMP.Model, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractACPForm}
+function voltagevariables(m::JuMP.AbstractModel, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractACPForm}
 
     on_set = [d.name for d in sys.buses if d.available == true]
 
@@ -17,7 +17,7 @@ function voltagevariables(m::JuMP.Model, system_formulation::Type{S}, sys::Power
     vm = @variable(m, vm[on_set,time_range])
 end
 
-function voltagevariables(m::JuMP.Model, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractACRForm}
+function voltagevariables(m::JuMP.AbstractModel, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractACRForm}
 
     on_set = [d.name for d in sys.buses if d.available == true]
 

--- a/src/device_models/branches/flow_constraints.jl
+++ b/src/device_models/branches/flow_constraints.jl
@@ -1,4 +1,4 @@
-function thermalflowlimits(m::JuMP.Model, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPForm}
+function thermalflowlimits(m::JuMP.AbstractModel, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPForm}
 
     fbr = m[:fbr]
     name_index = m[:fbr].axes[1]
@@ -28,7 +28,7 @@ function thermalflowlimits(m::JuMP.Model, system_formulation::Type{S}, devices::
     return m
 end
 
-function thermalflowlimits(m::JuMP.Model, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPLLForm}
+function thermalflowlimits(m::JuMP.AbstractModel, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPLLForm}
 
     fbr_fr = m[:fbr_fr]
     fbr_to = m[:fbr_to]

--- a/src/device_models/branches/flow_variables.jl
+++ b/src/device_models/branches/flow_variables.jl
@@ -1,5 +1,5 @@
 
-function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPForm}
+function flowvariables(m::JuMP.AbstractModel, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPForm}
 
     on_set = [d.name for d in devices if d.available == true]
 
@@ -10,7 +10,7 @@ function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Arra
 end
 
 
-function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPLLForm}
+function flowvariables(m::JuMP.AbstractModel, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: PM.AbstractDCPLLForm}
 
     on_set = [d.name for d in devices if d.available == true]
 
@@ -21,7 +21,7 @@ function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Arra
 
 end
 
-function flowvariables(m::JuMP.Model, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: AbstractACPowerModel}
+function flowvariables(m::JuMP.AbstractModel, system_formulation::Type{S}, devices::Array{B,1}, time_periods::Int64) where {B <: PowerSystems.Branch, S <: AbstractACPowerModel}
 
     on_set = [d.name for d in devices if d.available == true]
 

--- a/src/device_models/branches/ptdf_model.jl
+++ b/src/device_models/branches/ptdf_model.jl
@@ -1,4 +1,4 @@
-function dc_networkflow(m::JuMP.Model, netinjection::BalanceNamedTuple, PTDF::PTDFArray)
+function dc_networkflow(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, PTDF::PTDFArray)
 
     fbr = m[:fbr]
     name_index = m[:fbr].axes[1]

--- a/src/device_models/common/variable_cost.jl
+++ b/src/device_models/common/variable_cost.jl
@@ -1,4 +1,4 @@
-function gencost(m::JuMP.Model, variable::JuMPArray{JuMP.VariableRef}, cost_component::Function)
+function gencost(m::JuMP.AbstractModel, variable::JuMPArray{JuMP.VariableRef}, cost_component::Function)
 
     store = Array{JuMP.AbstractJuMPScalar,1}(undef,length(variable.axes[1]))
 
@@ -12,7 +12,7 @@ function gencost(m::JuMP.Model, variable::JuMPArray{JuMP.VariableRef}, cost_comp
 
 end
 
-function gencost(m::JuMP.Model, variable::JuMPArray{JuMP.VariableRef}, cost_component::Float64)
+function gencost(m::JuMP.AbstractModel, variable::JuMPArray{JuMP.VariableRef}, cost_component::Float64)
 
     gen_cost = sum(variable)*cost_component
 
@@ -20,7 +20,7 @@ function gencost(m::JuMP.Model, variable::JuMPArray{JuMP.VariableRef}, cost_comp
 
 end
 
-function pwlgencost(m::JuMP.Model, variable::VariableRef, cost_component::Array{Tuple{Float64, Float64}})
+function pwlgencost(m::JuMP.AbstractModel, variable::VariableRef, cost_component::Array{Tuple{Float64, Float64}})
 
     pwlvars = @variable(m, [i = 1:(length(cost_component)-1)], base_name = "pwl_{$(variable)}", start = 0.0, lower_bound = 0.0, upper_bound = (cost_component[i+1][1] - cost_component[i][1]))
      for (ix, pwlvar) in enumerate(pwlvars)
@@ -45,7 +45,7 @@ function pwlgencost(m::JuMP.Model, variable::VariableRef, cost_component::Array{
     return gen_cost
 end
 
-function gencost(m::JuMP.Model, variable::JuMPArray{JuMP.VariableRef}, cost_component::Array{Tuple{Float64, Float64}})
+function gencost(m::JuMP.AbstractModel, variable::JuMPArray{JuMP.VariableRef}, cost_component::Array{Tuple{Float64, Float64}})
 
     gen_cost = JuMP.AffExpr()
 

--- a/src/device_models/electric_loads/controlableload_cost.jl
+++ b/src/device_models/electric_loads/controlableload_cost.jl
@@ -1,4 +1,4 @@
-function variablecost(m::JuMP.Model, devices::Array{PowerSystems.InterruptibleLoad,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {D <: AbstractControllableLoadForm, S <: PM.AbstractPowerFormulation}
+function variablecost(m::JuMP.AbstractModel, devices::Array{PowerSystems.InterruptibleLoad,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {D <: AbstractControllableLoadForm, S <: PM.AbstractPowerFormulation}
 
     p_cl = m[:p_cl]
     time_index = m[:p_cl].axes[2]

--- a/src/device_models/electric_loads/load_variables.jl
+++ b/src/device_models/electric_loads/load_variables.jl
@@ -1,4 +1,4 @@
-function activepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where {T <: PowerSystems.ElectricLoad}
+function activepowervariables(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where {T <: PowerSystems.ElectricLoad}
 
     on_set = [d.name for d in devices]
 
@@ -9,7 +9,7 @@ function activepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods::
     return p_cl
 end
 
-function reactivepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where {T <: PowerSystems.ElectricLoad}
+function reactivepowervariables(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where {T <: PowerSystems.ElectricLoad}
 
     on_set = [d.name for d in devices]
 

--- a/src/device_models/electric_loads/shedding_constraints.jl
+++ b/src/device_models/electric_loads/shedding_constraints.jl
@@ -1,7 +1,7 @@
 """
 This function adds the power limits of generators when there are no CommitmentVariables
 """
-function activepower(m::JuMP.Model, devices::Array{L,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: PM.AbstractPowerFormulation}
+function activepower(m::JuMP.AbstractModel, devices::Array{L,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: PM.AbstractPowerFormulation}
 
     p_cl = m[:p_cl]
     time_index = m[:p_cl].axes[2]
@@ -25,7 +25,7 @@ function activepower(m::JuMP.Model, devices::Array{L,1}, device_formulation::Typ
 end
 
 
-function reactivepower(m::JuMP.Model, devices::Array{L,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: AbstractACPowerModel}
+function reactivepower(m::JuMP.AbstractModel, devices::Array{L,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {L <: PowerSystems.ElectricLoad, D <: AbstractControllableLoadForm, S <: AbstractACPowerModel}
 
     q_cl = m[:q_cl]
     p_cl = m[:p_cl]

--- a/src/device_models/hydro_generation/curtailment_constraints.jl
+++ b/src/device_models/hydro_generation/curtailment_constraints.jl
@@ -1,7 +1,7 @@
 """
 This function adds the power limits of  hydro generators when there are no CommitmentVariables
 """
-function powerconstraints(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.HydroCurtailment
+function powerconstraints(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.HydroCurtailment
 
     phy = m[:phy]
     time_index = m[:phy].axes[2]

--- a/src/device_models/hydro_generation/hydro_variables.jl
+++ b/src/device_models/hydro_generation/hydro_variables.jl
@@ -1,4 +1,4 @@
-function activepowervariables(m::JuMP.Model, devices_netinjection::A, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.HydroGen}
+function activepowervariables(m::JuMP.AbstractModel, devices_netinjection::A, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.HydroGen}
 
     on_set = [d.name for d in devices if d.available == true]
 

--- a/src/device_models/renewable_generation/output_constraints.jl
+++ b/src/device_models/renewable_generation/output_constraints.jl
@@ -1,7 +1,7 @@
 """
 This function adds the power limits of generators when there are no CommitmentVariables
 """
-function activepower(m::JuMP.Model, devices::Array{R,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {R <: PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm, S <: PM.AbstractPowerFormulation}
+function activepower(m::JuMP.AbstractModel, devices::Array{R,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {R <: PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm, S <: PM.AbstractPowerFormulation}
 
     p_re = m[:p_re]
     time_index = m[:p_re].axes[2]
@@ -29,7 +29,7 @@ end
 """
 This function adds the power limits of generators when there are no CommitmentVariables
 """
-function reactivepower(m::JuMP.Model, devices::Array{R,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {R <: PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm,  S <: AbstractACPowerModel}
+function reactivepower(m::JuMP.AbstractModel, devices::Array{R,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {R <: PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm,  S <: AbstractACPowerModel}
 
     q_re = m[:q_re]
     time_index = m[:q_re].axes[2]

--- a/src/device_models/renewable_generation/renewable_variables.jl
+++ b/src/device_models/renewable_generation/renewable_variables.jl
@@ -1,4 +1,4 @@
-function activepowervariables(m::JuMP.Model, devices::Array{R,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, R <: PowerSystems.RenewableGen}
+function activepowervariables(m::JuMP.AbstractModel, devices::Array{R,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, R <: PowerSystems.RenewableGen}
 
     on_set = [d.name for d in devices]
 
@@ -10,7 +10,7 @@ function activepowervariables(m::JuMP.Model, devices::Array{R,1}, time_periods::
 
 end
 
-function reactivepowervariables(m::JuMP.Model, devices::Array{R,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, R <: PowerSystems.RenewableGen}
+function reactivepowervariables(m::JuMP.AbstractModel, devices::Array{R,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, R <: PowerSystems.RenewableGen}
 
     on_set = [d.name for d in devices]
 

--- a/src/device_models/renewable_generation/renewablegen_cost.jl
+++ b/src/device_models/renewable_generation/renewablegen_cost.jl
@@ -1,4 +1,4 @@
-function variablecost(m::JuMP.Model, devices::Array{PowerSystems.RenewableCurtailment,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {D <: AbstractRenewableDispatchForm, S <: PM.AbstractPowerFormulation}
+function variablecost(m::JuMP.AbstractModel, devices::Array{PowerSystems.RenewableCurtailment,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {D <: AbstractRenewableDispatchForm, S <: PM.AbstractPowerFormulation}
 
     p_re = m[:p_re]
     time_index = m[:p_re].axes[2]

--- a/src/device_models/storage/book_keeping_constraints.jl
+++ b/src/device_models/storage/book_keeping_constraints.jl
@@ -1,5 +1,5 @@
 
-function powerconstraints(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.Storage
+function powerconstraints(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.Storage
 
     pstin = m[:pstin]
     pstout = m[:pstout]
@@ -35,7 +35,7 @@ function powerconstraints(m::JuMP.Model, devices::Array{T,1}, time_periods::Int6
     return m
 end
 
-function energybookkeeping(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64; ini_cond = 0.0) where T <: PowerSystems.GenericBattery
+function energybookkeeping(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64; ini_cond = 0.0) where T <: PowerSystems.GenericBattery
 
     pstin = m[:pstin]
     pstout = m[:pstout]
@@ -71,7 +71,7 @@ function energybookkeeping(m::JuMP.Model, devices::Array{T,1}, time_periods::Int
 
 end
 
-function energyconstraints(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.GenericBattery
+function energyconstraints(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.GenericBattery
 
     ebt = m[:ebt]
     name_index = m[:ebt].axes[1]

--- a/src/device_models/storage/storage_variables.jl
+++ b/src/device_models/storage/storage_variables.jl
@@ -1,4 +1,4 @@
-function powerstoragevariables(m::JuMP.Model, devices_netinjection:: A, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.Storage}
+function powerstoragevariables(m::JuMP.AbstractModel, devices_netinjection:: A, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.Storage}
 
     on_set = [d.name for d in devices if d.available]
     t = 1:time_periods
@@ -11,7 +11,7 @@ function powerstoragevariables(m::JuMP.Model, devices_netinjection:: A, devices:
     return pstin, pstout, devices_netinjection
 end
 
-function energystoragevariables(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.Storage
+function energystoragevariables(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.Storage
 
     on_set = [d.name for d in devices if d.available]
     t = 1:time_periods

--- a/src/device_models/thermal_generation/output_constraints.jl
+++ b/src/device_models/thermal_generation/output_constraints.jl
@@ -2,7 +2,7 @@
 """
 This function adds the power limits of generators when there are no CommitmentVariables
 """
-function activepower(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm, S <: PM.AbstractPowerFormulation}
+function activepower(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm, S <: PM.AbstractPowerFormulation}
 
     p_th = m[:p_th]
     time_index = m[:p_th].axes[2]
@@ -35,7 +35,7 @@ end
 """
 This function adds the power limits of generators when there are CommitmentVariables
 """
-function activepower(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: AbstractDCPowerModel}
+function activepower(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: AbstractDCPowerModel}
 
     p_th = m[:p_th]
     on_th = m[:on_th]
@@ -69,7 +69,7 @@ end
 """
 This function adds the power limits of generators when there are no CommitmentVariables
 """
-function reactivepower(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm, S <: AbstractACPowerModel}
+function reactivepower(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm, S <: AbstractACPowerModel}
 
     q_th = m[:q_th]
     time_index = m[:q_th].axes[2]
@@ -104,7 +104,7 @@ end
 """
 This function adds the power limits of generators when there are CommitmentVariables
 """
-function reactivepower(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: AbstractACPowerModel}
+function reactivepower(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: AbstractACPowerModel}
 
     q_th = m[:p_th]
     on_th = m[:on_th]

--- a/src/device_models/thermal_generation/ramping_constraints.jl
+++ b/src/device_models/thermal_generation/ramping_constraints.jl
@@ -2,7 +2,7 @@
 """
 This function adds the ramping limits of generators when there are no CommitmentVariables
 """
-function rampconstraints(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{ThermalRampLimitDispatch}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, S <: PM.AbstractPowerFormulation}
+function rampconstraints(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{ThermalRampLimitDispatch}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, S <: PM.AbstractPowerFormulation}
 
     devices = [d for d in devices if !isa(d.tech.ramplimits,Nothing)]
 
@@ -51,7 +51,7 @@ end
 """
 This function adds the ramping limits of generators when there are CommitmentVariables
 """
-function rampconstraints(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: AbstractDCPowerModel}
+function rampconstraints(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: AbstractDCPowerModel}
 
     devices = [d for d in devices if !isa(d.tech.ramplimits,Nothing)]
 

--- a/src/device_models/thermal_generation/thermal_variables.jl
+++ b/src/device_models/thermal_generation/thermal_variables.jl
@@ -3,7 +3,7 @@
 """
 This function add the variables for power generation output to the model
 """
-function activepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.ThermalGen}
+function activepowervariables(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.ThermalGen}
 
     on_set = [d.name for d in devices if d.available == true]
 
@@ -17,7 +17,7 @@ end
 """
 This function add the variables for power generation output to the model
 """
-function reactivepowervariables(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.ThermalGen}
+function reactivepowervariables(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where {A <: JumpExpressionMatrix, T <: PowerSystems.ThermalGen}
 
     on_set = [d.name for d in devices if d.available == true]
 
@@ -31,7 +31,7 @@ end
 """
 This function add the variables for power generation commitment to the model
 """
-function commitmentvariables(m::JuMP.Model, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.ThermalGen
+function commitmentvariables(m::JuMP.AbstractModel, devices::Array{T,1}, time_periods::Int64) where T <: PowerSystems.ThermalGen
 
     on_set = [d.name for d in devices if d.available == true]
 

--- a/src/device_models/thermal_generation/thermalgencommitment_cost.jl
+++ b/src/device_models/thermal_generation/thermalgencommitment_cost.jl
@@ -1,4 +1,4 @@
-function commitmentcost(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: PM.AbstractPowerFormulation}
+function commitmentcost(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm, S <: PM.AbstractPowerFormulation}
 
     on_th = m[:on_th]
     start_th = m[:start_th]

--- a/src/device_models/thermal_generation/thermalgenvariable_cost.jl
+++ b/src/device_models/thermal_generation/thermalgenvariable_cost.jl
@@ -1,4 +1,4 @@
-function variablecost(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm, S <: PM.AbstractPowerFormulation}
+function variablecost(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}) where {T <: PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm, S <: PM.AbstractPowerFormulation}
 
     p_th = m[:p_th]
     time_index = m[:p_th].axes[2]

--- a/src/device_models/thermal_generation/unitcommitment_constraints.jl
+++ b/src/device_models/thermal_generation/unitcommitment_constraints.jl
@@ -3,7 +3,7 @@
 """
 This function adds the Commitment Status constraint when there are CommitmentVariables
 """
-function commitmentconstraints(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, D <: StandardThermalCommitment, S <: AbstractDCPowerModel}
+function commitmentconstraints(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, D <: StandardThermalCommitment, S <: AbstractDCPowerModel}
 
     on_th = m[:on_th]
     start_th = m[:start_th]
@@ -46,7 +46,7 @@ function commitmentconstraints(m::JuMP.Model, devices::Array{T,1}, device_formul
 end
 
 
-function timeconstraints(m::JuMP.Model, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, D <: StandardThermalCommitment, S <: AbstractDCPowerModel}
+function timeconstraints(m::JuMP.AbstractModel, devices::Array{T,1}, device_formulation::Type{D}, system_formulation::Type{S}, time_periods::Int64; args...) where {T <: PowerSystems.ThermalGen, D <: StandardThermalCommitment, S <: AbstractDCPowerModel}
 
     devices = [d for d in devices if !isa(d.tech.timelimits, Nothing)]
 

--- a/src/network_models/copperplate_balance.jl
+++ b/src/network_models/copperplate_balance.jl
@@ -1,4 +1,4 @@
-function copperplatebalance(m::JuMP.Model, netinjection::BalanceNamedTuple, time_periods::Int64)
+function copperplatebalance(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, time_periods::Int64)
 
     devices_netinjection = remove_undef!(netinjection.var_active)
     timeseries_netinjection = sum(netinjection.timeseries_active, dims=1)

--- a/src/network_models/nodal_balance.jl
+++ b/src/network_models/nodal_balance.jl
@@ -1,4 +1,4 @@
-function add_flows(m::JuMP.Model, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractDCPForm}
+function add_flows(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractDCPForm}
 
     fbr = m[:fbr]
     branch_name_index = m[:fbr].axes[1]
@@ -14,7 +14,7 @@ function add_flows(m::JuMP.Model, netinjection::BalanceNamedTuple, system_formul
 
 end
 
-function add_flows(m::JuMP.Model, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractDCPLLForm}
+function add_flows(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: PM.AbstractDCPLLForm}
 
     fbr_fr = m[:fbr_fr]
     fbr_to = m[:fbr_to]
@@ -30,7 +30,7 @@ function add_flows(m::JuMP.Model, netinjection::BalanceNamedTuple, system_formul
 
 end
 
-function nodalflowbalance(m::JuMP.Model, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: AbstractFlowForm}
+function nodalflowbalance(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: AbstractFlowForm}
 
     time_index = 1:sys.time_periods
     bus_name_index = [b.name for b in sys.buses]
@@ -52,7 +52,7 @@ function nodalflowbalance(m::JuMP.Model, netinjection::BalanceNamedTuple, system
 end
 
 
-function nodalflowbalance(m::JuMP.Model, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: AbstractDCPowerModel}
+function nodalflowbalance(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: AbstractDCPowerModel}
 
     time_index = 1:sys.time_periods
     bus_name_index = [b.name for b in sys.buses]
@@ -69,7 +69,7 @@ function nodalflowbalance(m::JuMP.Model, netinjection::BalanceNamedTuple, system
 
 end
 
-function nodalflowbalance(m::JuMP.Model, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: AbstractACPowerModel}
+function nodalflowbalance(m::JuMP.AbstractModel, netinjection::BalanceNamedTuple, system_formulation::Type{S}, sys::PowerSystems.PowerSystem) where {S <: AbstractACPowerModel}
 
     nodalflowbalance(m, netinjection, AbstractDCPowerModel, sys)
 

--- a/src/service_models/reserves.jl
+++ b/src/service_models/reserves.jl
@@ -1,5 +1,5 @@
 
-function reservevariables(m::JuMP.Model, devices::Array{NamedTuple{(:device, :formulation), Tuple{R,DataType}}}, time_periods::Int64) where {R <: PowerSystems.PowerSystemDevice}
+function reservevariables(m::JuMP.AbstractModel, devices::Array{NamedTuple{(:device, :formulation), Tuple{R,DataType}}}, time_periods::Int64) where {R <: PowerSystems.PowerSystemDevice}
 
     on_set = [d.device.name for d in devices]
 
@@ -12,39 +12,39 @@ function reservevariables(m::JuMP.Model, devices::Array{NamedTuple{(:device, :fo
 end
 
 # headroom constraints
-function make_pmax_rsv_constraint(m::JuMP.Model,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm}
+function make_pmax_rsv_constraint(m::JuMP.AbstractModel,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.ThermalGen, D <: AbstractThermalDispatchForm}
     return @constraint(m, m[:p_th][device.name,t] + m[:p_rsv][device.name,t]  <= device.tech.activepowerlimits.max)
 end
 
-function make_pmax_rsv_constraint(m::JuMP.Model,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm}
+function make_pmax_rsv_constraint(m::JuMP.AbstractModel,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.ThermalGen, D <: AbstractThermalCommitmentForm}
     return @constraint(m, m[:p_th][device.name,t] + m[:p_rsv][device.name,t] <= device.tech.activepowerlimits.max * m[:on_th][device.name,t])
 end
 
-function make_pmax_rsv_constraint(m::JuMP.Model,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm}
+function make_pmax_rsv_constraint(m::JuMP.AbstractModel,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm}
     return @constraint(m, m[:p_re][device.name,t] + m[:p_rsv][device.name,t] <= device.tech.installedcapacity * values(device.scalingfactor)[t])
 end
 
-function make_pmax_rsv_constraint(m::JuMP.Model,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.InterruptibleLoad, D <: AbstractControllableLoadForm}
+function make_pmax_rsv_constraint(m::JuMP.AbstractModel,t::Int64, device::G, formulation::Type{D}) where {G<:PowerSystems.InterruptibleLoad, D <: AbstractControllableLoadForm}
     return @constraint(m, m[:p_cl][device.name,t] + m[:p_rsv][device.name,t] <= device.maxactivepower * values(device.scalingfactor)[t])
 end
 
 # ramp constraints
-function make_pramp_rsv_constraint(m::JuMP.Model,t::Int64, device::G, formulation::Type{D}, timeframe) where {G<:PowerSystems.ThermalGen, D <: AbstractThermalFormulation}
+function make_pramp_rsv_constraint(m::JuMP.AbstractModel,t::Int64, device::G, formulation::Type{D}, timeframe) where {G<:PowerSystems.ThermalGen, D <: AbstractThermalFormulation}
     rmax = device.tech.ramplimits != nothing  ? device.tech.ramplimits.up : device.tech.activepowerlimits.max
     return @constraint(m, m[:p_rsv][device.name,t] <= rmax/60 * timeframe)
 end
 
-function make_pramp_rsv_constraint(m::JuMP.Model,t::Int64, device::G, formulation::Type{D}, timeframe) where {G<:PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm}
+function make_pramp_rsv_constraint(m::JuMP.AbstractModel,t::Int64, device::G, formulation::Type{D}, timeframe) where {G<:PowerSystems.RenewableGen, D <: AbstractRenewableDispatchForm}
     return
 end
-function make_pramp_rsv_constraint(m::JuMP.Model,t::Int64, device::G, formulation::Type{D}, timeframe) where {G<:PowerSystems.InterruptibleLoad, D <: AbstractControllableLoadForm}
+function make_pramp_rsv_constraint(m::JuMP.AbstractModel,t::Int64, device::G, formulation::Type{D}, timeframe) where {G<:PowerSystems.InterruptibleLoad, D <: AbstractControllableLoadForm}
     #rmax =  device.maxactivepower * values(device.scalingfactor)[t] #nominally setting load ramp limit to full range within 1 min
     #return @constraint(m, m[:p_rsv][device.name,t] <= rmax/60 * timeframe)
     return
 end
 
 
-function reserves(m::JuMP.Model, devices::Array{NamedTuple{(:device, :formulation), Tuple{R,DataType}}}, service::PowerSystems.StaticReserve, time_periods::Int64) where {R <: PowerSystems.PowerSystemDevice}
+function reserves(m::JuMP.AbstractModel, devices::Array{NamedTuple{(:device, :formulation), Tuple{R,DataType}}}, service::PowerSystems.StaticReserve, time_periods::Int64) where {R <: PowerSystems.PowerSystemDevice}
 
     p_rsv = m[:p_rsv]
     time_index = m[:p_rsv].axes[2]

--- a/src/utils/cost_addition.jl
+++ b/src/utils/cost_addition.jl
@@ -1,4 +1,4 @@
-function add_to_cost!(m::JuMP.Model, cost_expression::Union{JuMP.JuMP.AffExpr, JuMP.JuMP.GenericQuadExpr})
+function add_to_cost!(m::JuMP.AbstractModel, cost_expression::Union{JuMP.JuMP.AffExpr, JuMP.JuMP.GenericQuadExpr})
 
     if haskey(m.obj_dict, :objective_function)
 

--- a/src/utils/device_retreval.jl
+++ b/src/utils/device_retreval.jl
@@ -36,11 +36,11 @@ end
 
 
 #TODO: Make additional methods to handle other device types
-function get_pg(m::JuMP.Model, gen::G, t::Int64) where G <: PowerSystems.ThermalGen
+function get_pg(m::JuMP.AbstractModel, gen::G, t::Int64) where G <: PowerSystems.ThermalGen
     return m.obj_dict[:p_th][gen.name,t]
 end
 
-function get_pg(m::JuMP.Model, gen::G, t::Int64) where G <: PowerSystems.RenewableCurtailment
+function get_pg(m::JuMP.AbstractModel, gen::G, t::Int64) where G <: PowerSystems.RenewableCurtailment
     return m.obj_dict[:p_re][gen.name,t]
 end
 
@@ -51,7 +51,7 @@ function get_all_vars(obj_dict)
     vars = [i for arr in var_arays for i in arr]
 end
 
-function map_moi_opt_variables(model::JuMP.Model)
+function map_moi_opt_variables(model::JuMP.AbstractModel)
     # maps moi variablerefs (keys) to optimizer variable refs (values)
     vmap = model.moi_backend.model.optimizer.variable_mapping
     moi_optimizer_vmap = Dict()
@@ -61,7 +61,7 @@ function map_moi_opt_variables(model::JuMP.Model)
     return moi_optimizer_vmap
 end
 
-function map_jump_vars(model::JuMP.Model)
+function map_jump_vars(model::JuMP.AbstractModel)
     # maps jump variablerefs (keys) to optimizer variable refs (values)
     vars = get_all_vars(model.obj_dict)
     moi_optimizer_vmap = map_moi_opt_variables(model)
@@ -71,7 +71,7 @@ function map_jump_vars(model::JuMP.Model)
 end
 
 
-function map_optimizer_vars(model::JuMP.Model)
+function map_optimizer_vars(model::JuMP.AbstractModel)
     # maps optimizer variablerefs (keys) to jump variable refs (values)
     vars = get_all_vars(model.obj_dict)
     moi_optimizer_vmap = map_moi_opt_variables(model)
@@ -87,7 +87,7 @@ function get_all_constraints(obj_dict)
     constraints = [i for arr in constraint_arrays for i in arr]
 end
 
-function map_moi_opt_constraints(model::JuMP.Model)
+function map_moi_opt_constraints(model::JuMP.AbstractModel)
     # maps moi constraintrefs (keys) to optimizer constraint refs (values)
     cmap = model.moi_backend.model.optimizer.constraint_mapping
     moi_optimizer_map = Dict()
@@ -100,7 +100,7 @@ function map_moi_opt_constraints(model::JuMP.Model)
     return moi_optimizer_map
 end
 
-function map_jump_constraints(model::JuMP.Model)
+function map_jump_constraints(model::JuMP.AbstractModel)
     # maps jump constraints (keys) to optimizer constraint refs (values)
     constraints = get_all_constraints(model.obj_dict)
     moi_optimizer_map = map_moi_opt_constraints(model)
@@ -108,7 +108,7 @@ function map_jump_constraints(model::JuMP.Model)
     return Dict(zip(constraints,moiconstraints))
 end
 
-function map_optimizer_constraints(model::JuMP.Model)
+function map_optimizer_constraints(model::JuMP.AbstractModel)
     # maps optimizer constraint refs (keys) to jump constraints (values)
     constraints = get_all_constraints(model.obj_dict)
     moi_optimizer_map = map_moi_opt_constraints(model)


### PR DESCRIPTION
Changing from concrete type to abstract type allows for flexibility and user defined models that are of type JuMP.AbstractModel.  This is a first step toward using scalable solvers.