### PR TITLE
Fix Min-up/down time constraints in UC formulation

### DIFF
--- a/src/devices/device_models/common/duration_constraints.jl
+++ b/src/devices/device_models/common/duration_constraints.jl
@@ -11,14 +11,14 @@ function device_duration_retrospective(ps_m::CanonicalModel,
                                         var_names::Tuple{Symbol,Symbol,Symbol})
 
     set_name = duration_data[1]
-
+    
     name_up = Symbol(cons_name,:_up)
     name_down = Symbol(cons_name,:_down)
 
     ps_m.constraints[name_up] = JuMP.Containers.DenseAxisArray{JuMP.ConstraintRef}(undef, set_name, time_range)
     ps_m.constraints[name_down] = JuMP.Containers.DenseAxisArray{JuMP.ConstraintRef}(undef, set_name, time_range)
 
-        for t in time_range, (ix,name) in enumerate(duration_data[1])
+        for t in time_range, (ix,name) in enumerate(set_name)
 
                 if t - duration_data[2][ix].up >= 1
                     tst = duration_data[2][ix].up
@@ -32,8 +32,8 @@ function device_duration_retrospective(ps_m::CanonicalModel,
                     tsd = max(1.0, duration_data[2][ix].down - initial_duration_off[ix].value)
                 end
 
-                ps_m.constraints[name_up][name, t] = JuMP.@constraint(ps_m.JuMPmodel, sum([ps_m.variables[var_names[2]][name,i] for i in ((t - tst + 1) :t) if i > 0 ]) <= ps_m.variables[var_names[1]][name,t])
-                ps_m.constraints[name_down][name, t] = JuMP.@constraint(ps_m.JuMPmodel, sum([ps_m.variables[var_names[3]][name,i] for i in ((t - tsd + 1) :t) if i > 0]) <= (1 - ps_m.variables[var_names[1]][name,t]))
+                ps_m.constraints[name_up][name, t] = JuMP.@constraint(ps_m.JuMPmodel, sum([ps_m.variables[var_names[2]][name,i] for i in ((t - round(tst) + 1) :t) if i > 0 ]) <= ps_m.variables[var_names[1]][name,t])
+                ps_m.constraints[name_down][name, t] = JuMP.@constraint(ps_m.JuMPmodel, sum([ps_m.variables[var_names[3]][name,i] for i in ((t - round(tsd) + 1) :t) if i > 0]) <= (1 - ps_m.variables[var_names[1]][name,t]))
 
         end
 

--- a/src/devices/device_models/thermal_generation.jl
+++ b/src/devices/device_models/thermal_generation.jl
@@ -373,7 +373,7 @@ function _get_data_for_tdc(devices::Array{T,1}) where {T <: PSY.ThermalGen}
     idx = eachindex(devices)
     i, state = iterate(idx)
     for g in devices
-        if !isnothing(g.tech.ramplimits)
+        if !isnothing(g.tech.timelimits)
             set_name[i] = g.name
             time_params[i] = g.tech.timelimits
             y = iterate(idx, state)

--- a/src/devices/device_models/thermal_generation.jl
+++ b/src/devices/device_models/thermal_generation.jl
@@ -404,6 +404,7 @@ function time_constraints(ps_m::CanonicalModel,
             @info("Initial conditions for time up/down not provided. This can lead to unwanted results")
             duration_init(ps_m, devices, parameters)
         end
+        @warn("Currently Min-up/down time limits only work if time resoultion they are defined at matches the simulation's time resoultion")
         device_duration_retrospective(ps_m,
                                       duration_data,
                                       ps_m.initial_conditions[:thermal_duration_on],


### PR DESCRIPTION
We need to round up minimum up/down time requirement to integers.
Would prefer to have this added in PowerSystems parsing checks, rather than in constraint creation
Fixes #124 