### PR TITLE
Pm interface refactor

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -53,9 +53,9 @@ version = "2.1.0"
 
 [[DataFrames]]
 deps = ["CategoricalArrays", "Compat", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "StatsBase", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "3891a62fd843662af9f78f25bdd415530b9b9c1e"
+git-tree-sha1 = "279baa6358fd5e944deccab88434f69c74cfc722"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.18.2"
+version = "0.18.3"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
@@ -216,9 +216,9 @@ version = "0.5.1"
 
 [[PowerModels]]
 deps = ["InfrastructureModels", "JSON", "JuMP", "LinearAlgebra", "MathOptInterface", "Memento", "SparseArrays"]
-git-tree-sha1 = "0c3b6fe78cd04b3c05eaf8ea49b4273bd03dbab1"
+git-tree-sha1 = "c9d4280b0cd1cd6dc10bca03d8c17950a1f90e8a"
 uuid = "c36e90e8-916a-50a6-bd94-075b64ef4655"
-version = "0.11.0"
+version = "0.11.1"
 
 [[PowerSystems]]
 deps = ["CSV", "DataFrames", "Dates", "InteractiveUtils", "JSON", "JSON2", "LinearAlgebra", "Logging", "SparseArrays", "TimeSeries", "UUIDs", "YAML"]

--- a/src/core/canonical_constructor.jl
+++ b/src/core/canonical_constructor.jl
@@ -53,7 +53,7 @@ function _powermodels_object_init(transmission::Type{S},
                                  base_power::Float64,
                                  time_steps::UnitRange{Int64},
                                  jump_model::JuMP.Model,
-                                 V::DataType) where {S <: PM.AbstractPowerFormulation}
+                                 V::DataType; kwargs...) where {S <: PM.AbstractPowerFormulation}
 
     is_activepower_only = (S <: PM.AbstractActivePowerFormulation)
     is_lossless_model = (S <: PM.DCPlosslessForm)

--- a/src/core/canonical_constructor.jl
+++ b/src/core/canonical_constructor.jl
@@ -44,15 +44,101 @@ function _make_expressions_dict(transmission::Type{S},
     return Dict{Symbol, JuMP.Containers.DenseAxisArray}(:nodal_balance_active => _make_container_array(V, bus_numbers, time_steps; kwargs...))
 end
 
+"""
+This function performs the same actions as the call to PowerModels.GenericPowerModel{T} but performs extra actions
+    to instantiate partially the power model object
+"""
+function _powermodels_object_init(transmission::Type{S},
+                                 buses::PSY.FlattenedVectorsIterator{PSY.Bus},
+                                 base_power::Float64,
+                                 time_steps::UnitRange{Int64},
+                                 jump_model::JuMP.Model,
+                                 V::DataType) where {S <: PM.AbstractPowerFormulation}
 
-function _canonical_model_init(bus_numbers::Vector{Int64},
+    is_activepower_only = (S <: PM.AbstractActivePowerFormulation)
+
+    PM_data_dict = Dict{String,Any}(
+        "bus"            => get_buses_to_pm(buses),
+        "branch"         => Dict{String,Any}(),
+        "baseMVA"        => base_power,
+        "per_unit"       => true,
+        "storage"        => Dict{String,Any}(),
+        "dcline"         => Dict{String,Any}(),
+        "gen"            => Dict{String,Any}(),
+        "shunt"          => Dict{String,Any}(),
+        "load"           => Dict{String,Any}(),
+        )
+
+    PM_data_dict = PM.replicate(PM_data_dict,time_steps[end]);
+
+    ext = Dict{Symbol,Any}()
+    setting = Dict{String,Any}()
+    ref = PM.build_generic_ref(PM_data_dict)
+
+    var = Dict{Symbol,Any}(:nw => Dict{Int,Any}())
+    con = Dict{Symbol,Any}(:nw => Dict{Int,Any}())
+
+    for (nw_id, nw) in ref[:nw]
+        nw_var = var[:nw][nw_id] = Dict{Symbol,Any}()
+        nw_con = con[:nw][nw_id] = Dict{Symbol,Any}()
+        ref[:nw][nw_id][:arcs_from] = Vector{Tuple{Int64,Int64,Int64}}()
+        ref[:nw][nw_id][:arcs_to] = Vector{Tuple{Int64,Int64,Int64}}()
+        ref[:nw][nw_id][:arcs_from_dc] = Vector{Tuple{Int64,Int64,Int64}}()
+        ref[:nw][nw_id][:arcs_to_dc] = Vector{Tuple{Int64,Int64,Int64}}()
+        ref[:nw][nw_id][:arcs] = Vector{Tuple{Int64,Int64,Int64}}()
+        ref[:nw][nw_id][:arcs_dc] = Vector{Tuple{Int64,Int64,Int64}}()
+
+        nw_var[:cnd] = Dict{Int,Any}()
+        nw_con[:cnd] = Dict{Int,Any}()
+
+        for cnd_id in nw[:conductor_ids]
+            nw_var[:cnd][cnd_id] = Dict{Symbol,Any}()
+            nw_var[:cnd][cnd_id][:p] = Vector{V}()
+            nw_var[:cnd][cnd_id][:p_dc] = Vector{V}()
+            is_activepower_only ? nw_var[:cnd][cnd_id][:q] = Vector{V}() : true
+            is_activepower_only ? nw_var[:cnd][cnd_id][:q_dc] = Vector{V}() : true
+            nw_con[:cnd][cnd_id] = Dict{Symbol,Any}()
+        end
+    end
+
+    cnw = minimum([k for k in keys(var[:nw])])
+    ccnd = minimum([k for k in keys(var[:nw][cnw][:cnd])])
+
+    pm_object = PM.GenericPowerModel{transmission}(
+                                        jump_model,
+                                        PM_data_dict,
+                                        setting,
+                                        Dict{String,Any}(), # solution
+                                        ref,
+                                        var,
+                                        con,
+                                        cnw,
+                                        ccnd,
+                                        ext
+                                    )
+
+    return pm_object
+
+end
+
+
+function _canonical_model_init(buses::PSY.FlattenedVectorsIterator{PSY.Bus},
+                              base_power::Float64,
                               optimizer::Union{Nothing,JuMP.OptimizerFactory},
                               transmission::Type{S},
                               time_steps::UnitRange{Int64}; kwargs...) where {S <: PM.AbstractPowerFormulation}
 
+
+    bus_numbers = [b.number for b in buses]
     parameters = get(kwargs, :parameters, true)
     jump_model = _pass_abstract_jump(optimizer; kwargs...)
     V = JuMP.variable_type(jump_model)
+    pm_object = _powermodels_object_init(transmission,
+                                                buses,
+                                            base_power,
+                                            time_steps,
+                                            jump_model,
+                                            V; kwargs ...)
 
     ps_model = CanonicalModel(jump_model,
                             Dict{Symbol, JuMP.Containers.DenseAxisArray}(),
@@ -61,17 +147,19 @@ function _canonical_model_init(bus_numbers::Vector{Int64},
                             _make_expressions_dict(transmission, V, bus_numbers, time_steps; kwargs...),
                             parameters ? Dict{Symbol,JuMP.Containers.DenseAxisArray}() : nothing,
                             Dict{Symbol,Array{InitialCondition}}(),
-                            nothing);
+                            pm_object);
 
     return ps_model
 
 end
 
-function _canonical_model_init(bus_numbers::Vector{Int64},
+function _canonical_model_init(buses::PSY.FlattenedVectorsIterator{PSY.Bus},
+                               base_power::Float64,
                                optimizer::Union{Nothing,JuMP.OptimizerFactory},
                                transmission::Type{S},
                                time_steps::UnitRange{Int64}; kwargs...) where {S <: Union{StandardPTDFForm, CopperPlatePowerModel}}
 
+    bus_numbers = [b.number for b in buses]
     parameters = get(kwargs, :parameters, true)
     jump_model = _pass_abstract_jump(optimizer; kwargs...)
     V = JuMP.variable_type(jump_model)
@@ -109,9 +197,9 @@ function  build_canonical_model(transmission::Type{T},
         time_steps = 1:1
     end
 
-    bus_numbers = [b.number for b in PSY.get_components(PSY.Bus, sys)]
+    buses = PSY.get_components(PSY.Bus, sys)
 
-    ps_model = _canonical_model_init(bus_numbers, optimizer, transmission, time_steps; kwargs...)
+    ps_model = _canonical_model_init(buses, sys.basepower, optimizer, transmission, time_steps; kwargs...)
 
     # Build Injection devices
     for mod in devices

--- a/src/core/canonical_constructor.jl
+++ b/src/core/canonical_constructor.jl
@@ -56,6 +56,7 @@ function _powermodels_object_init(transmission::Type{S},
                                  V::DataType) where {S <: PM.AbstractPowerFormulation}
 
     is_activepower_only = (S <: PM.AbstractActivePowerFormulation)
+    is_lossless_model = (S <: PM.DCPlosslessForm)
 
     PM_data_dict = Dict{String,Any}(
         "bus"            => get_buses_to_pm(buses),
@@ -71,7 +72,7 @@ function _powermodels_object_init(transmission::Type{S},
 
     PM_data_dict = PM.replicate(PM_data_dict,time_steps[end]);
 
-    ext = Dict{Symbol,Any}()
+    ext = Dict{Symbol,Any}(:arc_ix => 0) # counter for PowerModels Archs
     setting = Dict{String,Any}()
     ref = PM.build_generic_ref(PM_data_dict)
 
@@ -93,10 +94,10 @@ function _powermodels_object_init(transmission::Type{S},
 
         for cnd_id in nw[:conductor_ids]
             nw_var[:cnd][cnd_id] = Dict{Symbol,Any}()
-            nw_var[:cnd][cnd_id][:p] = Vector{V}()
+            nw_var[:cnd][cnd_id][:p] = is_lossless_model ? Dict{Tuple{Int64,Int64,Int64},Any}() : Vector{V}()
             nw_var[:cnd][cnd_id][:p_dc] = Vector{V}()
-            is_activepower_only ? nw_var[:cnd][cnd_id][:q] = Vector{V}() : true
-            is_activepower_only ? nw_var[:cnd][cnd_id][:q_dc] = Vector{V}() : true
+            is_activepower_only ? true : nw_var[:cnd][cnd_id][:q] = Vector{V}()
+            is_activepower_only ? true : nw_var[:cnd][cnd_id][:q_dc] = Vector{V}()
             nw_con[:cnd][cnd_id] = Dict{Symbol,Any}()
         end
     end

--- a/src/core/canonical_constructor.jl
+++ b/src/core/canonical_constructor.jl
@@ -72,7 +72,8 @@ function _powermodels_object_init(transmission::Type{S},
 
     PM_data_dict = PM.replicate(PM_data_dict,time_steps[end]);
 
-    ext = Dict{Symbol,Any}(:arc_ix => 0) # counter for PowerModels Archs
+    ext = Dict{Symbol,Any}(:arc_ix => 0,    # counter for AC Branch PowerModels Archs
+                           :dc_arc_ix => 0) # counter for DC Branch PowerModels Archs
     setting = Dict{String,Any}()
     ref = PM.build_generic_ref(PM_data_dict)
 

--- a/src/devices/device_constructors/branch_constructor.jl
+++ b/src/devices/device_constructors/branch_constructor.jl
@@ -27,18 +27,19 @@ function _internal_device_constructor!(ps_m::CanonicalModel,
 end
 
 function _internal_device_constructor!(ps_m::CanonicalModel,
-                            device::Type{B},
-                            device_formulation::Type{Br},
-                            system_formulation::Type{S},
-                            sys::PSY.System,
-                            time_steps::UnitRange{Int64},
-                            resolution::Dates.Period;
-                            kwargs...) where {Br <: AbstractBranchFormulation,
-                                              B <: PSY.Branch,
-                                              S <: PM.AbstractPowerFormulation}
+                                        device::Type{B},
+                                        device_formulation::Type{Br},
+                                        system_formulation::Type{S},
+                                        sys::PSY.System,
+                                        time_steps::UnitRange{Int64},
+                                        resolution::Dates.Period;
+                                        kwargs...) where {Br <: AbstractBranchFormulation,
+                                                          B <: PSY.Branch,
+                                                          S <: PM.AbstractPowerFormulation}
 
+    devices = PSY.get_components(device, sys)
 
-    # This code is meant to do nothing and will have a constructor once the branch formulations are developed
+    flow_variables(ps_m, system_formulation, devices, time_steps)
 
     return
 

--- a/src/devices/device_models/AC_branches.jl
+++ b/src/devices/device_models/AC_branches.jl
@@ -37,9 +37,6 @@ function flow_variables(ps_m::CanonicalModel,
 
 end
 
-
-
-
 function flow_variables(ps_m::CanonicalModel,
                         system_formulation::Type{S},
                         devices::PSY.FlattenedVectorsIterator{B},

--- a/src/devices/device_models/DC_branches.jl
+++ b/src/devices/device_models/DC_branches.jl
@@ -6,7 +6,7 @@ struct HVDC <: AbstractDCLineForm end
 
 struct VoltageSourceDC <: AbstractDCLineForm end
 
-
+#=
 function flow_variables(ps_m::CanonicalModel,
                         system_formulation::Type{S},
                         devices::Array{B,1},
@@ -23,5 +23,223 @@ function flow_variables(ps_m::CanonicalModel,
                  time_steps,
                  Symbol("Fbr_fr_$(B)"),
                  false)
+
+end
+=#
+
+function flow_variables(ps_m::CanonicalModel,
+                        system_formulation::Type{S},
+                        devices::PSY.FlattenedVectorsIterator{B},
+                        time_steps::UnitRange{Int64}) where {B <: PSY.DCBranch,
+                                                             S <: PM.AbstractPowerFormulation}
+    #Get PowerModels dicts
+    pm_object = ps_m.pm_model
+    ref = pm_object.ref
+    var = pm_object.var
+    dc_arc_ix = pm_object.ext[:dc_arc_ix]
+
+    var_name_from_p = Symbol("PDCbr_fr_$(B)")
+    var_name_to_p = Symbol("PDCbr_to_$(B)")
+    var_name_from_q = Symbol("QDCbr_fr_$(B)")
+    var_name_to_q = Symbol("QDCbr_to_$(B)")
+
+    ps_m.variables[var_name_to_p] = PSI._container_spec(ps_m.JuMPmodel,
+                                                       (d.name for d in devices),
+                                                       time_steps)
+
+    ps_m.variables[var_name_from_p] = PSI._container_spec(ps_m.JuMPmodel,
+                                                          (d.name for d in devices),
+                                                          time_steps)
+
+
+    ps_m.variables[var_name_to_q] = PSI._container_spec(ps_m.JuMPmodel,
+                                                       (d.name for d in devices),
+                                                       time_steps)
+
+    ps_m.variables[var_name_from_q] = PSI._container_spec(ps_m.JuMPmodel,
+                                                          (d.name for d in devices),
+                                                          time_steps)
+
+
+    for (ix, d) in enumerate(devices)
+        dc_arc_ix = dc_arc_ix + 1
+        bus_fr = d.connectionpoints.from.number
+        bus_to = d.connectionpoints.to.number
+        arcs_fr = (dc_arc_ix, bus_fr, bus_to)
+        arcs_to = (dc_arc_ix, bus_to, bus_fr)
+
+        for t in time_steps
+            ref[:nw][t][:dcline][dc_arc_ix] = PSI.get_branch_to_pm(dc_arc_ix, d)
+            push!(ref[:nw][t][:arcs_from_dc], arcs_fr)
+            push!(ref[:nw][t][:arcs_to_dc], arcs_to)
+            #careful here the order of the push has to match the order of the variable creation
+            push!(ref[:nw][t][:arcs_dc], arcs_fr, arcs_to)
+
+            #Active Power Variables
+            ps_m.variables[var_name_from_p][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                                                            base_name="$(bus_fr),$(bus_to)_{$(d.name),$(t)}",
+                                                                            upper_bound = d.rate,
+                                                                            lower_bound = -d.rate,
+                                                                            start = 0.0)
+
+            push!(var[:nw][t][:cnd][1][:P], ps_m.variables[var_name_from_p][d.name,t])
+
+            ps_m.variables[var_name_to_p][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                                                        base_name="$(bus_to),$(bus_fr)_{$(d.name),$(t)}",
+                                                                        upper_bound = d.rate,
+                                                                        lower_bound = -d.rate,
+                                                                        start = 0.0)
+
+            push!(var[:nw][t][:cnd][1][:P], ps_m.variables[var_name_to_p][d.name,t])
+
+            #reactive Power Variables
+            ps_m.variables[var_name_from_q][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                                                        base_name="$(bus_fr),$(bus_to)_{$(d.name),$(t)}",
+                                                                        upper_bound = d.rate,
+                                                                        lower_bound = -d.rate,
+                                                                        start = 0.0)
+
+            push!(var[:nw][t][:cnd][1][:q_dc], ps_m.variables[var_name_from_q][d.name,t])
+
+            ps_m.variables[var_name_to_q][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                                                        base_name="$(bus_to),$(bus_fr)_{$(d.name),$(t)}",
+                                                                        upper_bound = d.rate,
+                                                                        lower_bound = -d.rate,
+                                                                        start = 0.0)
+
+            push!(var[:nw][t][:cnd][1][:q_dc], ps_m.variables[var_name_to_q][d.name,t])
+
+        end
+
+
+    end
+
+    pm_object.ext[:dc_arc_ix] = dc_arc_ix
+
+    return
+
+end
+
+function flow_variables(ps_m::CanonicalModel,
+                        system_formulation::Type{S},
+                        devices::PSY.FlattenedVectorsIterator{B},
+                        time_steps::UnitRange{Int64}) where {B <: PSY.DCBranch,
+                                                             S <: PM.AbstractActivePowerFormulation}
+
+    #Get PowerModels dicts
+    pm_object = ps_m.pm_model
+    ref = pm_object.ref
+    var = pm_object.var
+    dc_arc_ix = pm_object.ext[:dc_arc_ix]
+
+    var_name_from_p = Symbol("PDCbr_fr_$(B)")
+    var_name_to_p = Symbol("PDCbr_to_$(B)")
+
+    ps_m.variables[var_name_to_p] = PSI._container_spec(ps_m.JuMPmodel,
+                                                       (d.name for d in devices),
+                                                       time_steps)
+
+    ps_m.variables[var_name_from_p] = PSI._container_spec(ps_m.JuMPmodel,
+                                                          (d.name for d in devices),
+                                                          time_steps)
+
+    for (ix, d) in enumerate(devices)
+        dc_arc_ix = dc_arc_ix + 1
+        bus_fr = d.connectionpoints.from.number
+        bus_to = d.connectionpoints.to.number
+        arcs_fr = (dc_arc_ix, bus_fr, bus_to)
+        arcs_to = (dc_arc_ix, bus_to, bus_fr)
+
+        for t in time_steps
+            ref[:nw][t][:dcline][dc_arc_ix] = PSI.get_branch_to_pm(dc_arc_ix, d)
+            push!(ref[:nw][t][:arcs_from_dc], arcs_fr)
+            push!(ref[:nw][t][:arcs_to_dc], arcs_to)
+            #careful here the order of the push has to match the order of the variable creation
+            push!(ref[:nw][t][:arcs_dc], arcs_fr, arcs_to)
+
+            #Active Power Variables
+            ps_m.variables[var_name_from_p][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                                                            base_name="$(bus_fr),$(bus_to)_{$(d.name),$(t)}",
+                                                                            upper_bound = d.rate,
+                                                                            lower_bound = -d.rate,
+                                                                            start = 0.0)
+
+            push!(var[:nw][t][:cnd][1][:P], ps_m.variables[var_name_from_p][d.name,t])
+
+            ps_m.variables[var_name_to_p][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                                                        base_name="$(bus_to),$(bus_fr)_{$(d.name),$(t)}",
+                                                                        upper_bound = d.rate,
+                                                                        lower_bound = -d.rate,
+                                                                        start = 0.0)
+
+            push!(var[:nw][t][:cnd][1][:P], ps_m.variables[var_name_to_p][d.name,t])
+
+        end
+
+
+    end
+
+    pm_object.ext[:dc_arc_ix] = dc_arc_ix
+
+    return
+
+
+    return
+
+end
+
+
+function flow_variables(ps_m::CanonicalModel,
+                        system_formulation::Type{S},
+                        devices::PSY.FlattenedVectorsIterator{B},
+                        time_steps::UnitRange{Int64}) where {B <: PSY.DCBranch,
+                                                            S <: PM.DCPlosslessForm}
+
+    #Get PowerModels dicts
+    pm_object = ps_m.pm_model
+    ref = pm_object.ref
+    var = pm_object.var
+    dc_arc_ix = pm_object.ext[:dc_arc_ix]
+
+    var_name = Symbol("DCbr_$(B)")
+
+    ps_m.variables[var_name] = PSI._container_spec(ps_m.JuMPmodel,
+                                                   (d.name for d in devices),
+                                                    time_steps)
+
+    for (ix, d) in enumerate(devices)
+        dc_arc_ix = dc_arc_ix + 1
+        bus_fr = d.connectionpoints.from.number
+        bus_to = d.connectionpoints.to.number
+        arcs_fr = (dc_arc_ix, bus_fr, bus_to)
+        arcs_to = (dc_arc_ix, bus_to, bus_fr)
+
+        for t in time_steps
+            ref[:nw][t][:dcline][dc_arc_ix] = PSI.get_branch_to_pm(dc_arc_ix, d)
+            push!(ref[:nw][t][:arcs_from_dc], arcs_fr)
+            push!(ref[:nw][t][:arcs_to_dc], arcs_to)
+            #careful here the order of the push has to match the order of the variable creation
+            push!(ref[:nw][t][:arcs_dc], arcs_fr, arcs_to)
+
+            #Active Power Variables
+            ps_m.variables[var_name][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                                                base_name="$(bus_fr),$(bus_to)_{$(d.name),$(t)}",
+                                                                upper_bound = d.rate,
+                                                                lower_bound = -d.rate,
+                                                                 start = 0.0)
+
+            var[:nw][t][:cnd][1][:P][arcs_fr] = ps_m.variables[var_name][d.name,t]
+            var[:nw][t][:cnd][1][:P][arcs_to] = -1*ps_m.variables[var_name][d.name,t]
+
+        end
+
+    end
+
+    pm_object.ext[:dc_arc_ix] = dc_arc_ix
+
+    return
+
+
+    return
 
 end

--- a/src/devices/device_models/common/pm_translator.jl
+++ b/src/devices/device_models/common/pm_translator.jl
@@ -143,13 +143,19 @@ function get_branches_to_pm(sys::PSY.System)
     return PM_ac_branches, PM_dc_branches
 end
 
-function get_buses_to_pm(buses::Array{PSY.Bus})
+function get_buses_to_pm(buses::PSY.FlattenedVectorsIterator{PSY.Bus})
     PM_buses = Dict{String,Any}()
     for bus in buses
         PM_bus = Dict{String,Any}(
         "zone"     => 1,
         "bus_i"    => bus.number,
-        "bus_type" => 2,
+        if bus.bustype == "PV"
+            "bus_type" => 1
+        elseif bus.bustype == "PQ"
+            "bus_type" => 2
+        elseif bus.bustype == "SF"
+            "bus_type" => 3
+        end,
         "vmax"     => bus.voltagelimits.max,
         "area"     => 1,
         "vmin"     => bus.voltagelimits.min,
@@ -162,7 +168,6 @@ function get_buses_to_pm(buses::Array{PSY.Bus})
         )
         PM_buses["$(bus.number)"] = PM_bus
     end
-    PM_buses["$(buses[1].number)"]["bus_type"] = 3
     return PM_buses
 end
 

--- a/src/devices/device_models/thermal_generation.jl
+++ b/src/devices/device_models/thermal_generation.jl
@@ -54,13 +54,29 @@ function reactivepower_variables(ps_m::CanonicalModel,
                                  devices::PSY.FlattenedVectorsIterator{T},
                                  time_steps::UnitRange{Int64}) where {T <: PSY.ThermalGen}
 
+
+    var_name = Symbol("Qth_$(T)")
+    ps_m.variables[var_name] = _container_spec(ps_m.JuMPmodel, (d.name for d in devices), time_steps)
+
+   for t in time_steps, d in devices
+       ps_m.variables[var_name][d.name,t] = JuMP.@variable(ps_m.JuMPmodel,
+                                             base_name="{$(var_name)}_{$(d.name),$(t)}",
+                                             upper_bound = d.tech.reactivepowerlimits.max,
+                                             lower_bound = d.tech.reactivepowerlimits.min,
+                                             start = d.tech.reactivepower)
+       _add_to_expression!(ps_m.expressions[:nodal_balance_reactive],
+                           d.bus.number,
+                           t,
+                           ps_m.variables[var_name][d.name,t])
+   end
+   #=
     add_variable(ps_m,
                  devices,
                  time_steps,
                  Symbol("Qth_$(T)"),
                  false,
                  :nodal_balance_reactive)
-
+    =#
     return
 
 end

--- a/src/network/network_models/powermodels_interface.jl
+++ b/src/network/network_models/powermodels_interface.jl
@@ -23,19 +23,21 @@ function psi_ref!(nw_refs::Dict)
 
         ### filter out inactive components ###
         ref[:bus] = Dict(x for x in ref[:bus] if x.second["bus_type"] != 4)
-        ref[:load] = Dict(x for x in ref[:load] if (x.second["status"] == 1 && x.second["load_bus"] in keys(ref[:bus])))
+        #ref[:load] = Dict(x for x in ref[:load] if (x.second["status"] == 1 && x.second["load_bus"] in keys(ref[:bus])))
         ref[:shunt] = Dict(x for x in ref[:shunt] if (x.second["status"] == 1 && x.second["shunt_bus"] in keys(ref[:bus])))
-        ref[:gen] = Dict(x for x in ref[:gen] if (x.second["gen_status"] == 1 && x.second["gen_bus"] in keys(ref[:bus])))
-        ref[:storage] = Dict(x for x in ref[:storage] if (x.second["status"] == 1 && x.second["storage_bus"] in keys(ref[:bus])))
+        #ref[:gen] = Dict(x for x in ref[:gen] if (x.second["gen_status"] == 1 && x.second["gen_bus"] in keys(ref[:bus])))
+        #ref[:storage] = Dict(x for x in ref[:storage] if (x.second["status"] == 1 && x.second["storage_bus"] in keys(ref[:bus])))
         ref[:branch] = Dict(x for x in ref[:branch] if (x.second["br_status"] == 1 && x.second["f_bus"] in keys(ref[:bus]) && x.second["t_bus"] in keys(ref[:bus])))
         ref[:dcline] = Dict(x for x in ref[:dcline] if (x.second["br_status"] == 1 && x.second["f_bus"] in keys(ref[:bus]) && x.second["t_bus"] in keys(ref[:bus])))
 
         ### bus connected component lookups ###
+        #=
         bus_loads = Dict((i, Int64[]) for (i,bus) in ref[:bus])
         for (i, load) in ref[:load]
             push!(bus_loads[load["load_bus"]], i)
         end
         ref[:bus_loads] = bus_loads
+        =#
 
         bus_shunts = Dict((i, Int64[]) for (i,bus) in ref[:bus])
         for (i,shunt) in ref[:shunt]
@@ -43,17 +45,19 @@ function psi_ref!(nw_refs::Dict)
         end
         ref[:bus_shunts] = bus_shunts
 
+        #=
         bus_gens = Dict((i, Int64[]) for (i,bus) in ref[:bus])
         for (i,gen) in ref[:gen]
             push!(bus_gens[gen["gen_bus"]], i)
         end
         ref[:bus_gens] = bus_gens
-
+        
         bus_storage = Dict((i, Int64[]) for (i,bus) in ref[:bus])
         for (i,strg) in ref[:storage]
             push!(bus_storage[strg["storage_bus"]], i)
         end
         ref[:bus_storage] = bus_storage
+        =#
 
         bus_arcs = Dict((i, Tuple{Int64,Int64,Int64}[]) for (i,bus) in ref[:bus])
         for (l,i,j) in ref[:arcs]

--- a/src/network/network_models/powermodels_interface.jl
+++ b/src/network/network_models/powermodels_interface.jl
@@ -347,6 +347,10 @@ function powermodels_network!(ps_m::CanonicalModel,
         end
     end
 
+    psi_ref!(pm_object)
+
+    post_nip_expr!(pm_object)
+
     return
 
 end

--- a/src/network/network_models/powermodels_interface.jl
+++ b/src/network/network_models/powermodels_interface.jl
@@ -51,7 +51,7 @@ function psi_ref!(nw_refs::Dict)
             push!(bus_gens[gen["gen_bus"]], i)
         end
         ref[:bus_gens] = bus_gens
-        
+
         bus_storage = Dict((i, Int64[]) for (i,bus) in ref[:bus])
         for (i,strg) in ref[:storage]
             push!(bus_storage[strg["storage_bus"]], i)
@@ -337,14 +337,14 @@ function powermodels_network!(ps_m::CanonicalModel,
 
     buses = PSY.get_components(PSY.Bus,sys)
     pm_object = ps_m.pm_model
-    var = ps_m.pm_model.var
-    ref = ps_m.pm_model.ref
     _remove_undef!(ps_m.expressions[:nodal_balance_active])
     _remove_undef!(ps_m.expressions[:nodal_balance_reactive])
 
     for t in time_steps
-        var[:nw][t][:cnd][1][:p] = JuMP.Containers.DenseAxisArray(var[:nw][t][:cnd][1][:p],ref[:nw][t][:arcs])
-        var[:nw][t][:cnd][1][:q] = JuMP.Containers.DenseAxisArray(var[:nw][t][:cnd][1][:q],ref[:nw][t][:arcs])
+        var = PM.var(pm_object, t, 1)
+        arcs = PM.ref(pm_object, t, :arcs)
+        var[:p] = JuMP.Containers.DenseAxisArray(var[:p], arcs)
+        var[:q] = JuMP.Containers.DenseAxisArray(var[:q], arcs)
         for bus in buses
             pm_object.data["nw"]["$(t)"]["bus"]["$(bus.number)"]["pni"] = ps_m.expressions[:nodal_balance_active][bus.number,t]
             pm_object.data["nw"]["$(t)"]["bus"]["$(bus.number)"]["qni"] = ps_m.expressions[:nodal_balance_reactive][bus.number,t]
@@ -368,13 +368,13 @@ function powermodels_network!(ps_m::CanonicalModel,
 
     buses = PSY.get_components(PSY.Bus,sys)
     pm_object = ps_m.pm_model
-    var = ps_m.pm_model.var
-    ref = ps_m.pm_model.ref
     _remove_undef!(ps_m.expressions[:nodal_balance_active])
 
     for t in time_steps
         if !(S <: PM.DCPlosslessForm)
-            var[:nw][t][:cnd][1][:p] = JuMP.Containers.DenseAxisArray(var[:nw][t][:cnd][1][:p],ref[:nw][t][:arcs])
+            var = PM.var(pm_object, t, 1)
+            arcs = PM.ref(pm_object, t, :arcs)
+            var[:p] = JuMP.Containers.DenseAxisArray(var[:p],arcs)
         end
         for bus in buses
             pm_object.data["nw"]["$(t)"]["bus"]["$(bus.number)"]["pni"] = ps_m.expressions[:nodal_balance_active][bus.number,t]

--- a/src/routines/optimization_debugging.jl
+++ b/src/routines/optimization_debugging.jl
@@ -6,5 +6,18 @@ function get_constraint_index(op_model::OperationModel)
             push!(con_index,(key, idx, moi_index.value))
         end
     end
+    @info "Each Tuple corresponds to (con_name, internal_index, moi_index)"
     return con_index
+end
+
+function get_var_index(op_model::OperationModel)
+    var_index = Vector{Tuple{Symbol, Int64, Int64}}()
+    for (key,value) in op_model.canonical_model.variables
+        for (idx,variable) in enumerate(value)
+            moi_index = JuMP.optimizer_index(variable);
+            push!(var_index,(key, idx, moi_index.value))
+        end
+    end
+    @info "Each Tuple corresponds to (var_name, internal_index, moi_index)"
+    return var_index
 end

--- a/test/load_constructors.jl
+++ b/test/load_constructors.jl
@@ -1,24 +1,24 @@
 @testset "Load data misspecification" begin
     model = DeviceModel(PSY.InterruptibleLoad, PSI.DispatchablePowerLoad)
     warn_message = "The data doesn't devices of type InterruptibleLoad, consider changing the device models"
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     @test_logs (:warn, warn_message) construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Hour(1));
     model = DeviceModel(PSY.PowerLoad, PSI.DispatchablePowerLoad)
     warn_message = "The Formulation PowerSimulations.DispatchablePowerLoad only applies to Controllable Loads, \n Consider Changing the Device Formulation to StaticPowerLoad"
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     @test_logs (:warn, warn_message) construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Hour(1));
 end
 
 @testset "Load Dispatchable DCPLossLess" begin
     model = DeviceModel(PSY.PowerLoad, PSI.DispatchablePowerLoad)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No parameters testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Hour(1); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
@@ -29,14 +29,14 @@ end
 
 @testset "Load Dispatchable ACP" begin
     model = DeviceModel(PSY.PowerLoad, PSI.DispatchablePowerLoad)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Hour(1); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
@@ -47,14 +47,14 @@ end
 
 @testset "Load Static DCPLossLess" begin
     model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Hour(1); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
@@ -65,14 +65,14 @@ end
 
 @testset "Load Static ACP" begin
     model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false);
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Hour(1); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0

--- a/test/network_constructors.jl
+++ b/test/network_constructors.jl
@@ -12,6 +12,7 @@ buses14 = PSY.get_components(PSY.Bus, c_sys14)
     ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
@@ -25,6 +26,7 @@ buses14 = PSY.get_components(PSY.Bus, c_sys14)
     ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false);
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false);
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps; parameters = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
@@ -39,6 +41,9 @@ buses14 = PSY.get_components(PSY.Bus, c_sys14)
     ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
@@ -52,6 +57,9 @@ buses14 = PSY.get_components(PSY.Bus, c_sys14)
     ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false);
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false);
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps; parameters = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
@@ -70,6 +78,7 @@ end
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps; PTDF = PTDF5)
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 264
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
@@ -84,6 +93,7 @@ end
     ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps; PTDF = PTDF5, parameters = false)
     @test JuMP.num_variables(ps_model.JuMPmodel) == 264
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -100,6 +110,9 @@ end
     ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps; PTDF = PTDF14)
     @test JuMP.num_variables(ps_model.JuMPmodel) == 600
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -115,6 +128,9 @@ end
     ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps; PTDF = PTDF14, parameters = false)
     @test JuMP.num_variables(ps_model.JuMPmodel) == 600
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -141,6 +157,7 @@ end
     ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 384
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
@@ -155,6 +172,7 @@ end
     ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps; parameters = false)
     @test JuMP.num_variables(ps_model.JuMPmodel) == 384
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
@@ -170,6 +188,9 @@ end
     ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 936
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
@@ -184,6 +205,9 @@ end
     ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps; parameters = false)
     @test JuMP.num_variables(ps_model.JuMPmodel) == 936
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
@@ -201,6 +225,7 @@ end
     ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 1056
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
@@ -215,6 +240,7 @@ end
     ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
+    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 1056
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
@@ -230,6 +256,9 @@ end
     ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 2832
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
@@ -244,6 +273,9 @@ end
     ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
+    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys14, time_steps);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 2832
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
@@ -263,6 +295,7 @@ end
         ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
         JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
         JuMP.optimize!(ps_model.JuMPmodel)
@@ -271,6 +304,7 @@ end
         ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
+        construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps; parameters = false)
         JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
         JuMP.optimize!(ps_model.JuMPmodel)
@@ -280,6 +314,9 @@ end
         ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+        construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys14, time_steps);
         JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
         JuMP.optimize!(ps_model.JuMPmodel)
@@ -288,6 +325,9 @@ end
         ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
+        construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys14, time_steps; parameters = false)
         JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
         JuMP.optimize!(ps_model.JuMPmodel)
@@ -307,12 +347,16 @@ end
         ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
         @test !isnothing(ps_model.pm_model)
         #14 Bus Testing
         ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+        construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys14, time_steps);
         @test !isnothing(ps_model.pm_model)
     end
@@ -327,6 +371,7 @@ end
         ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
         JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
         JuMP.optimize!(ps_model.JuMPmodel)
@@ -335,6 +380,9 @@ end
         ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+        construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys14, time_steps);
         JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
         JuMP.optimize!(ps_model.JuMPmodel)
@@ -354,12 +402,16 @@ end
         ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
         @test !isnothing(ps_model.pm_model)
         #14 Bus Testing
         ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
+        construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys14, time_steps);
         @test !isnothing(ps_model.pm_model)
     end

--- a/test/network_constructors.jl
+++ b/test/network_constructors.jl
@@ -132,7 +132,7 @@ end
 @testset  "Network Solve AC-PF PowerModels linear approximation models" begin
     networks = [PM.DCPlosslessForm, PM.NFAForm]
     for network in networks
-        @info "Testing $(network)"
+        @info "Testing construction of a $(network) network"
         ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
@@ -184,7 +184,7 @@ end
                 ]
 
     for network in networks
-        @info "Testing $(network)"
+        @info "Testing construction of a $(network) network"
         ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
@@ -208,7 +208,7 @@ end
     networks = [PM.StandardDCPLLForm, PM.AbstractLPACCForm]
 
     for network in networks
-        @info "Testing $(network)"
+        @info "Testing construction of a $(network) network"
         ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
@@ -239,7 +239,7 @@ end
                  ]
 
     for network in networks
-        @info "Testing $(network)"
+        @info "Testing construction of a $(network) network"
         ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));

--- a/test/network_constructors.jl
+++ b/test/network_constructors.jl
@@ -2,11 +2,14 @@ thermal_model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch)
 load_model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
 line_model = DeviceModel(PSY.Line, PSI.ACSeriesBranch)
 transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
+ttransformer_model = DeviceModel(PSY.TapTransformer, PSI.ACSeriesBranch)
+buses5 = PSY.get_components(PSY.Bus, c_sys5)
+buses14 = PSY.get_components(PSY.Bus, c_sys14)
 
 @testset "Network Copper Plate" begin
     #5- Bus - Testing
     network = PSI.CopperPlatePowerModel
-    ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps);
@@ -19,7 +22,7 @@ transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
     JuMP.optimize!(ps_model.JuMPmodel)
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false);
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false);
     construct_network!(ps_model, network, c_sys5, time_steps; parameters = false);
@@ -33,7 +36,7 @@ transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
     #14- Bus - Testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_network!(ps_model, network, c_sys14, time_steps);
@@ -46,7 +49,7 @@ transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
     JuMP.optimize!(ps_model.JuMPmodel)
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false);
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false);
     construct_network!(ps_model, network, c_sys14, time_steps; parameters = false);
@@ -63,7 +66,7 @@ end
 @testset "Network DC-PF with PTDF formulation" begin
     #5-Bus testing
     network = PSI.StandardPTDFForm
-    ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps; PTDF = PTDF5)
@@ -78,7 +81,7 @@ end
 
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_network!(ps_model, network, c_sys5, time_steps; PTDF = PTDF5, parameters = false)
@@ -94,7 +97,7 @@ end
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
     #14 Bus Testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_network!(ps_model, network, c_sys14, time_steps; PTDF = PTDF14)
@@ -109,7 +112,7 @@ end
 
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_network!(ps_model, network, c_sys14, time_steps; PTDF = PTDF14, parameters = false)
@@ -125,7 +128,7 @@ end
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
     #PTDF input Error testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
     @test_throws ArgumentError construct_network!(ps_model, network, c_sys5, time_steps)
@@ -135,7 +138,7 @@ end
 @testset "Network DC-PF network with PowerModels DCPlosslessForm" begin
     #5 Bus Testing
     network = PM.DCPlosslessForm
-    ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps);
@@ -149,7 +152,7 @@ end
 
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_network!(ps_model, network, c_sys5, time_steps; parameters = false)
@@ -164,7 +167,7 @@ end
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
     #14 Bus Testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_network!(ps_model, network, c_sys14, time_steps);
@@ -178,7 +181,7 @@ end
 
     @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_network!(ps_model, network, c_sys14, time_steps; parameters = false)
@@ -195,7 +198,7 @@ end
 
 @testset  "Network Solve AC-PF PowerModels StandardACPForm" begin
     network = PM.StandardACPForm
-    ps_model = PSI._canonical_model_init(bus_numbers5, ipopt_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
     construct_network!(ps_model, network, c_sys5, time_steps);
@@ -209,7 +212,7 @@ end
 
     @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, ipopt_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     construct_network!(ps_model, network, c_sys5, time_steps);
@@ -224,7 +227,7 @@ end
     @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
 
     #14 Bus Testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, ipopt_optimizer, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
     construct_network!(ps_model, network, c_sys14, time_steps);
@@ -238,7 +241,7 @@ end
 
     @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, ipopt_optimizer, network, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps; parameters = false)
     construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
     construct_network!(ps_model, network, c_sys14, time_steps);
@@ -257,7 +260,7 @@ end
     networks = [PM.DCPlosslessForm, PM.NFAForm]
     for network in networks
         @info "Testing $(network)"
-        ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
@@ -265,7 +268,7 @@ end
         JuMP.optimize!(ps_model.JuMPmodel)
         @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-        ps_model = PSI._canonical_model_init(bus_numbers5, GLPK_optimizer, network, time_steps; parameters = false)
+        ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
         construct_network!(ps_model, network, c_sys5, time_steps; parameters = false)
@@ -274,7 +277,7 @@ end
         @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
         #14 Bus Testing
-        ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_network!(ps_model, network, c_sys14, time_steps);
@@ -282,7 +285,7 @@ end
         JuMP.optimize!(ps_model.JuMPmodel)
         @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
 
-        ps_model = PSI._canonical_model_init(bus_numbers14, GLPK_optimizer, network, time_steps; parameters = false)
+        ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
         construct_network!(ps_model, network, c_sys14, time_steps; parameters = false)
@@ -301,13 +304,13 @@ end
 
     for network in networks
         @info "Testing $(network)"
-        ps_model = PSI._canonical_model_init(bus_numbers5, ipopt_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
         @test !isnothing(ps_model.pm_model)
         #14 Bus Testing
-        ps_model = PSI._canonical_model_init(bus_numbers14, ipopt_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_network!(ps_model, network, c_sys14, time_steps);
@@ -321,7 +324,7 @@ end
 
     for network in networks
         @info "Testing $(network)"
-        ps_model = PSI._canonical_model_init(bus_numbers5, ipopt_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
@@ -329,7 +332,7 @@ end
         JuMP.optimize!(ps_model.JuMPmodel)
         @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
         #14 Bus Testing
-        ps_model = PSI._canonical_model_init(bus_numbers14, ipopt_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_network!(ps_model, network, c_sys14, time_steps);
@@ -348,13 +351,13 @@ end
 
     for network in networks
         @info "Testing $(network)"
-        ps_model = PSI._canonical_model_init(bus_numbers5, ipopt_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_network!(ps_model, network, c_sys5, time_steps);
         @test !isnothing(ps_model.pm_model)
         #14 Bus Testing
-        ps_model = PSI._canonical_model_init(bus_numbers14, ipopt_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
         construct_network!(ps_model, network, c_sys14, time_steps);
@@ -371,7 +374,7 @@ end
                     PM.SOCBFConicForm]
 
     for network in incompat_list
-        ps_model = PSI._canonical_model_init(bus_numbers5, ipopt_optimizer, network, time_steps)
+        ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
         construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
         construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
         @test_throws ArgumentError construct_network!(ps_model, network, c_sys5, time_steps);

--- a/test/network_constructors.jl
+++ b/test/network_constructors.jl
@@ -3,145 +3,64 @@ load_model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
 line_model = DeviceModel(PSY.Line, PSI.ACSeriesBranch)
 transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
 ttransformer_model = DeviceModel(PSY.TapTransformer, PSI.ACSeriesBranch)
-buses5 = PSY.get_components(PSY.Bus, c_sys5)
-buses14 = PSY.get_components(PSY.Bus, c_sys14)
 
 @testset "Network Copper Plate" begin
-    #5- Bus - Testing
-    network = PSI.CopperPlatePowerModel
-    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 24
+    network = CopperPlatePowerModel
+    systems = [c_sys5, c_sys14]
+    parameters = [true, false]
+    test_results = Dict{PSY.System, Vector{Int64}}(c_sys5 => [120, 120, 0, 0, 24],  
+                                                   c_sys14 => [120, 120, 0, 0, 24])
+    
+    for (ix,sys) in enumerate(systems), p in parameters 
+        buses = get_components(PSY.Bus, sys)
+        base = sys.basepower
+        ps_model = PSI._canonical_model_init(buses, base, OSQP_optimizer, network, time_steps; parameters = p)
+        construct_device!(ps_model, thermal_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, load_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, line_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_network!(ps_model, network, sys, time_steps; parameters = p);
+        @test JuMP.num_variables(ps_model.JuMPmodel) == test_results[sys][1]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == test_results[sys][2]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == test_results[sys][3]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == test_results[sys][4]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == test_results[sys][5]
 
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false);
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false);
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps; parameters = false);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 24
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    #14- Bus - Testing
-    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 24
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false);
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false);
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps; parameters = false);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 24
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
+        JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
+        JuMP.optimize!(ps_model.JuMPmodel)
+        @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
+    end
 end
 
 @testset "Network DC-PF with PTDF formulation" begin
-    #5-Bus testing
-    network = PSI.StandardPTDFForm
-    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps; PTDF = PTDF5)
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 264
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 264
+    network = StandardPTDFForm
+    systems = [c_sys5, c_sys14]
+    parameters = [true, false]
+    PTDF_ref = Dict{PSY.System, PSY.PTDF}(c_sys5 => PTDF5, c_sys14 => PTDF14)
+    test_results = Dict{PSY.System, Vector{Int64}}(c_sys5 => [264, 120, 0, 0, 264],  
+                                                    c_sys14 => [600, 120, 0, 0, 816])
+    
+    for (ix,sys) in enumerate(systems), p in parameters 
+        buses = get_components(PSY.Bus, sys)
+        base = sys.basepower
+        ps_model = PSI._canonical_model_init(buses, base, OSQP_optimizer, network, time_steps; parameters = p)
+        construct_device!(ps_model, thermal_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, load_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, line_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_network!(ps_model, network, sys, time_steps; PTDF = PTDF_ref[sys], parameters = p);
+        @test JuMP.num_variables(ps_model.JuMPmodel) == test_results[sys][1]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == test_results[sys][2]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == test_results[sys][3]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == test_results[sys][4]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == test_results[sys][5]
 
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps; PTDF = PTDF5, parameters = false)
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 264
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 264
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    #14 Bus Testing
-    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps; PTDF = PTDF14)
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 600
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 816
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps; PTDF = PTDF14, parameters = false)
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 600
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 816
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
+        JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
+        JuMP.optimize!(ps_model.JuMPmodel)
+        @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
+    end
 
     #PTDF input Error testing
     ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
@@ -151,141 +70,63 @@ end
 end
 
 
-@testset "Network DC-PF network with PowerModels DCPlosslessForm" begin
-    #5 Bus Testing
+@testset "Network DC lossless -PF network with PowerModels DCPlosslessForm" begin
     network = PM.DCPlosslessForm
-    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 384
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 288
+    systems = [c_sys5, c_sys14]
+    parameters = [true, false]
+    test_results = Dict{PSY.System, Vector{Int64}}(c_sys5 => [384, 120, 144, 144, 288],  
+                                                    c_sys14 => [936, 120, 480, 480, 840])
+    
+    for (ix,sys) in enumerate(systems), p in parameters 
+        buses = get_components(PSY.Bus, sys)
+        base = sys.basepower
+        ps_model = PSI._canonical_model_init(buses, base, OSQP_optimizer, network, time_steps; parameters = p)
+        construct_device!(ps_model, thermal_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, load_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, line_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_network!(ps_model, network, sys, time_steps; parameters = p);
+        @test JuMP.num_variables(ps_model.JuMPmodel) == test_results[sys][1]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == test_results[sys][2]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == test_results[sys][3]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == test_results[sys][4]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == test_results[sys][5]
 
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    ps_model = PSI._canonical_model_init(buses5, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps; parameters = false)
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 384
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 288
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    #14 Bus Testing
-    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 936
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 840
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
-
-    ps_model = PSI._canonical_model_init(buses14, 100.0, GLPK_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps; parameters = false)
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 936
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 840
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
+        JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
+        JuMP.optimize!(ps_model.JuMPmodel)
+        @test termination_status(ps_model.JuMPmodel) == MOI.OPTIMAL
+    end
+   
 end
 
 @testset  "Network Solve AC-PF PowerModels StandardACPForm" begin
     network = PM.StandardACPForm
-    ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 1056
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 264
+    systems = [c_sys5, c_sys14]
+    parameters = [true, false]
+    test_results = Dict{PSY.System, Vector{Int64}}(c_sys5 => [1056, 240, 144, 144, 264],  
+                                                    c_sys14 => [2832, 240, 480, 480, 696])
 
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
+    for (ix,sys) in enumerate(systems), p in parameters 
+        buses = get_components(PSY.Bus, sys)
+        base = sys.basepower
+        ps_model = PSI._canonical_model_init(buses, base, ipopt_optimizer, network, time_steps; parameters = p)
+        construct_device!(ps_model, thermal_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, load_model, network, sys, time_steps, Dates.Hour(1); parameters = p);
+        construct_device!(ps_model, line_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, transformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_device!(ps_model, ttransformer_model, network, sys, time_steps, Dates.Minute(5));
+        construct_network!(ps_model, network, sys, time_steps; parameters = p);
+        @test JuMP.num_variables(ps_model.JuMPmodel) == test_results[sys][1]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == test_results[sys][2]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == test_results[sys][3]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == test_results[sys][4]
+        @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == test_results[sys][5]
 
-    @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
-
-    ps_model = PSI._canonical_model_init(buses5, 100.0, ipopt_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
-    construct_device!(ps_model, load_model, network, c_sys5, time_steps, Dates.Minute(5); parameters = false)
-    construct_device!(ps_model, line_model, network, c_sys5, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys5, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 1056
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 144
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 264
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
-
-    #14 Bus Testing
-    ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1));
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 2832
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 696
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
-
-    ps_model = PSI._canonical_model_init(buses14, 100.0, ipopt_optimizer, network, time_steps; parameters = false)
-    construct_device!(ps_model, thermal_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
-    construct_device!(ps_model, load_model, network, c_sys14, time_steps, Dates.Hour(1); parameters = false)
-    construct_device!(ps_model, line_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, transformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_device!(ps_model, ttransformer_model, network, c_sys14, time_steps, Dates.Minute(5));
-    construct_network!(ps_model, network, c_sys14, time_steps);
-    @test JuMP.num_variables(ps_model.JuMPmodel) == 2832
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 480
-    @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 696
-
-    JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
-    JuMP.optimize!(ps_model.JuMPmodel)
-
-    @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
+        JuMP.@objective(ps_model.JuMPmodel, Min, AffExpr(0))
+        JuMP.optimize!(ps_model.JuMPmodel)
+        @test termination_status(ps_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
+    end
 end
 
 @testset  "Network Solve AC-PF PowerModels linear approximation models" begin
@@ -363,7 +204,7 @@ end
 
 end
 
-@testset  "Network AC-PF PowerModels quadratic approximations models" begin
+@testset  "Network AC-PF PowerModels quadratic loss approximations models" begin
     networks = [PM.StandardDCPLLForm, PM.AbstractLPACCForm]
 
     for network in networks

--- a/test/operation_model_constructor.jl
+++ b/test/operation_model_constructor.jl
@@ -1,13 +1,11 @@
+devices = Dict{Symbol, DeviceModel}(:Generators => DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch),
+                                    :Loads =>  DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad))
+branches = Dict{Symbol, DeviceModel}(:L => DeviceModel(PSY.Line, PSI.ACSeriesBranch),
+                                     :T => DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch),
+                                     :TT => DeviceModel(PSY.TapTransformer , PSI.ACSeriesBranch))
+services = Dict{Symbol, PSI.ServiceModel}()
 @testset "Operation Model kwargs with CopperPlatePowerModel base" begin
-    thermal_model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch)
-    load_model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
-    line_model = DeviceModel(PSY.Line, PSI.ACSeriesBranch)
-    devices = Dict{Symbol, DeviceModel}(:Generators => thermal_model, :Loads =>  load_model)
-    branches = Dict{Symbol, DeviceModel}(:Lines => line_model)
-    services = Dict{Symbol, PSI.ServiceModel}()
-
     model_ref = ModelReference(CopperPlatePowerModel, devices, branches, services);
-
     op_model = OperationModel(TestOptModel, model_ref,
                                             c_sys5;
                                             optimizer = GLPK_optimizer)
@@ -110,123 +108,8 @@ end
     end
 
 end
+
 #=
-@testset "Operation Model Constructors without Parameters" begin
-    networks = [PSI.CopperPlatePowerModel,
-                PSI.StandardPTDFForm,
-                PM.DCPlosslessForm,
-                PM.NFAForm,
-                PM.StandardACPForm,
-                PM.StandardACRForm,
-                PM.StandardACTForm,
-                PM.StandardDCPLLForm,
-                PM.AbstractLPACCForm,
-                PM.SOCWRForm,
-                PM.QCWRForm,
-                PM.QCWRTriForm]
-
-    thermal_gens = [PSI.ThermalUnitCommitment,
-                    PSI.ThermalDispatch,
-                    PSI.ThermalRampLimited,
-                    PSI.ThermalDispatchNoMin]
-
-    systems = [c_sys5,
-               c_sys5_re,
-               c_sys5_bat];
-
-    load_model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
-    line_model = DeviceModel(PSY.Line, PSI.ACSeriesBranch)
-    transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
-
-    for net in networks, thermal in thermal_gens, system in systems
-        @testset "Operation Model $(net) - $(thermal) - $(system)" begin
-            thermal_model = DeviceModel(PSY.ThermalStandard, thermal)
-            devices = Dict{Symbol, DeviceModel}(:Generators => thermal_model, :Loads =>  load_model)
-            branches = Dict{Symbol, DeviceModel}(:Lines => line_model)
-            services = Dict{Symbol, PSI.ServiceModel}()
-            model_ref = ModelReference(net, devices, branches, services);
-            op_model = OperationModel(TestOptModel,
-                                        model_ref,
-                                        system;
-                                        parameters = false,
-                                        PTDF = PTDF5)
-        @test :nodal_balance_active in keys(op_model.canonical_model.expressions)
-        @test !(:params in keys(op_model.canonical_model.JuMPmodel.ext))
-        end
-
-
-    end
-
-end
-
-@testset "RTS test set" begin
-    networks = [PSI.CopperPlatePowerModel,
-                PSI.StandardPTDFForm,
-                PM.DCPlosslessForm,
-                PM.NFAForm,
-                PM.StandardACPForm,
-                PM.StandardACRForm,
-                PM.StandardACTForm,
-                PM.StandardDCPLLForm,
-                PM.AbstractLPACCForm,
-                PM.SOCWRForm,
-                PM.QCWRForm,
-                PM.QCWRTriForm]
-
-    thermal_gens = [PSI.ThermalUnitCommitment,
-                    PSI.ThermalDispatch,
-                    PSI.ThermalRampLimited,
-                    PSI.ThermalDispatchNoMin]
-
-    systems = [c_sys5,
-               c_sys5_re,
-               c_sys5_bat];
-
-    renewable_curtailment_model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableConstantPowerFactor)
-    thermal_model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch)
-    hvdc_model = DeviceModel(PSY.HVDCLine, PSI.DCSeriesBranch)
-    #hydro = DeviceModel(PSY.HydroDispatch, PSI.HydroDispatch)
-    transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
-    tap_transformer_model = DeviceModel(PSY.TapTransformer, PSI.ACSeriesBranch)
-    renewable_fix = DeviceModel(PSY.RenewableFix, PSI.RenewableFixed)
-    load_model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
-    line_model = DeviceModel(PSY.Line, PSI.ACSeriesBranch)
-    bat = DeviceModel(PSY.GenericBattery, PSI.BookKeeping)
-
-    devices = Dict{Symbol, DeviceModel}(:Generators => thermal_model,
-                                    :Loads =>  load_model,
-                                    :rc => renewable_curtailment_model,
-                                    :ren_fix => renewable_fix)
-    branches = Dict{Symbol, DeviceModel}(:Lines => line_model,
-                                    :HVDC => hvdc_model,
-                                    :tap_trafo => tap_transformer_model,
-                                    :trafo => transformer_model)
-    services = Dict{Symbol, PSI.ServiceModel}()
-    net = PSI.CopperPlatePowerModel
-
-
-    for net in networks, thermal in thermal_gens, system in systems
-        @testset "Operation Model $(net) - $(thermal) - $(system)" begin
-            thermal_model = DeviceModel(PSY.ThermalStandard, thermal)
-            devices = Dict{Symbol, DeviceModel}(:Generators => thermal_model, :Loads =>  load_model)
-            branches = Dict{Symbol, DeviceModel}(:Lines => line_model, :Transformer)
-            services = Dict{Symbol, PSI.ServiceModel}()
-            op_model = OperationModel(TestOptModel, net,
-                                        devices,
-                                        branches,
-                                        services,
-                                        system;
-                                        parameters = false,
-                                        PTDF = PTDF5)
-        @test :nodal_balance_active in keys(op_model.canonical_model.expressions)
-        @test !(:params in keys(op_model.canonical_model.JuMPmodel.ext))
-        end
-
-
-    end
-
-end
-
 @testset "Build Operation Models" begin
     #SCED = PSI.SCEconomicDispatch(c_sys5; optimizer = GLPK_optimizer);
     #OPF = PSI.OptimalPowerFlow(c_sys5, PM.StandardACPForm, optimizer = ipopt_optimizer)

--- a/test/operation_model_solve.jl
+++ b/test/operation_model_solve.jl
@@ -10,9 +10,9 @@ services = Dict{Symbol, PSI.ServiceModel}()
     parameters_value = [true, false]
     systems = [c_sys5, c_sys14]
     test_results = Dict{PSY.System, Float64}(c_sys5 => 240000.0,  
-                                             c_sys14 => 120000.0)
+                                             c_sys14 => 142000.0)
     for sys in systems, p in parameters_value
-        @info("Testing ED CopperPlatePowerModel solve")
+        @info("Testing solve ED with CopperPlatePowerModel network")
         @testset "ED CopperPlatePowerModel model parameters = $(p)" begin
         ED = OperationModel(TestOptModel, model_ref, sys; optimizer = OSQP_optimizer, parameters = p)
         res = solve_op_model!(ED)
@@ -28,10 +28,10 @@ end
     systems = [c_sys5, c_sys14]
     PTDF_ref = Dict{PSY.System, PSY.PTDF}(c_sys5 => PTDF5, c_sys14 => PTDF14)
     test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
-                                             c_sys14 => 140000.0)
+                                             c_sys14 => 142000.0)
 
     for sys in systems, p in parameters_value
-        @info("Testing ED StandardPTDFForm solve")
+        @info("Testing solve ED with StandardPTDFForm network")
         @testset "ED StandardPTDFForm model parameters = $(p)" begin
         ED = OperationModel(TestOptModel, model_ref, sys; PTDF = PTDF_ref[sys], optimizer = OSQP_optimizer, parameters = p)
         res = solve_op_model!(ED)
@@ -47,10 +47,10 @@ end
     networks = [PM.DCPlosslessForm,
                 PM.NFAForm]
     test_results = Dict{PSY.System, Float64}(c_sys5 => 320000.0,  
-                                             c_sys14 => 140000.0)
+                                             c_sys14 => 142000.0)
 
     for  net in networks, p in parameters_value, sys in systems
-        @info("Testing ED $(net) solve")
+        @info("Testing solve ED with $(net) network")
         @testset "ED model $(net) and parameters = $(p)" begin
         model_ref = ModelReference(net, devices, branches, services);
         ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
@@ -63,16 +63,16 @@ end
 
 end
 
-@testset "Solving ED With PowerModels with loss-less convex models" begin
+@testset "Solving ED With PowerModels with linear convex models" begin
     systems = [c_sys5, c_sys14]
     parameters_value = [true, false]
     networks = [PM.StandardDCPLLForm, 
                 PM.AbstractLPACCForm]
     test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
-                                             c_sys14 => 140000.0)
+                                             c_sys14 => 142000.0)
 
     for  net in networks, p in parameters_value, sys in systems
-        @info("Testing ED $(net) solve")
+        @info("Testing solve ED with $(net) network")
         @testset "ED model $(net) and parameters = $(p)" begin
         model_ref = ModelReference(net, devices, branches, services);
         ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
@@ -92,10 +92,10 @@ end
                  PM.QCWRForm,
                  PM.QCWRTriForm,]
     test_results = Dict{PSY.System, Float64}(c_sys5 => 320000.0,  
-                                             c_sys14 => 140000.0)
+                                             c_sys14 => 142000.0)
 
     for  net in networks, p in parameters_value, sys in systems
-        @info("Testing ED $(net) solve")
+        @info("Testing solve ED with $(net) network")
         @testset "ED model $(net) and parameters = $(p)" begin
         model_ref = ModelReference(net, devices, branches, services);
         ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
@@ -115,10 +115,10 @@ end
                 PM.StandardACRForm,
                 PM.StandardACTForm]
         test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
-                                             c_sys14 => 140000.0)
+                                             c_sys14 => 142000.0)
 
     for  net in networks, p in parameters_value, sys in systems
-        @info("Testing ED $(net) solve")
+        @info("Testing solve ED with $(net) network")
         @testset "ED model $(net) and parameters = $(p)" begin
         model_ref = ModelReference(net, devices, branches, services);
         ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
@@ -141,7 +141,7 @@ end
                 CopperPlatePowerModel]
 
     for  net in networks, p in parameters_value, sys in systems
-        @info("Testing UC $(net) solve")
+        @info("Testing solve UC with $(net) network")
         @testset "UC model $(net) and parameters = $(p)" begin
         model_ref= ModelReference(net, devices, branches, services);
         UC = OperationModel(TestOptModel, model_ref, sys; PTDF = PTDF5, optimizer = GLPK_optimizer, parameters = p)

--- a/test/operation_model_solve.jl
+++ b/test/operation_model_solve.jl
@@ -1,89 +1,132 @@
+devices = Dict{Symbol, DeviceModel}(:Generators => DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch),
+                                    :Loads =>  DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad))
+branches = Dict{Symbol, DeviceModel}(:L => DeviceModel(PSY.Line, PSI.ACSeriesBranch),
+                                     :T => DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch),
+                                     :TT => DeviceModel(PSY.TapTransformer , PSI.ACSeriesBranch))
+services = Dict{Symbol, PSI.ServiceModel}()
+
 @testset "Solving ED with CopperPlate" begin
-    devices = Dict{Symbol, DeviceModel}(:Generators => DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch),
-                                        :Loads =>  DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad))
-    branches = Dict{Symbol, DeviceModel}()
-    services = Dict{Symbol, PSI.ServiceModel}()
     model_ref = ModelReference(CopperPlatePowerModel, devices, branches, services);
-
     parameters_value = [true, false]
-
-    for p in parameters_value
+    systems = [c_sys5, c_sys14]
+    test_results = Dict{PSY.System, Float64}(c_sys5 => 240000.0,  
+                                             c_sys14 => 120000.0)
+    for sys in systems, p in parameters_value
         @info("Testing ED CopperPlatePowerModel solve")
         @testset "ED CopperPlatePowerModel model parameters = $(p)" begin
-        ED = OperationModel(TestOptModel, model_ref, c_sys5; optimizer = GLPK_optimizer, parameters = p)
-        res_5 = solve_op_model!(ED)
+        ED = OperationModel(TestOptModel, model_ref, sys; optimizer = OSQP_optimizer, parameters = p)
+        res = solve_op_model!(ED)
         @test termination_status(ED.canonical_model.JuMPmodel) == MOI.OPTIMAL
-        @test isapprox(res_5.total_cost[:OBJECTIVE_FUNCTION], 240000, atol = 10000)
-        #14 Bus Test
-        #ED = OperationModel(TestOptModel, model_ref, c_sys14; optimizer = OSQP_optimizer, parameters = p);
-        #res_14 = solve_op_model!(ED)
-        #@test termination_status(ED.canonical_model.JuMPmodel) == MOI.OPTIMAL
-        #@test isapprox(res_14.total_cost[:OBJECTIVE_FUNCTION], 120000, atol = 10000)
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 10000)
         end
     end
-    #RTS Test
-    #ED = EconomicDispatch(sys_rts, CopperPlatePowerModel; optimizer = GLPK_optimizer);
-    #res_rts = solve_op_model!(ED)
 end
 
 @testset "Solving ED with PTDF Models" begin
-    devices = Dict{Symbol, DeviceModel}(:Generators => DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch),
-                                        :Loads =>  DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad))
-    branches = Dict{Symbol, DeviceModel}()
-    services = Dict{Symbol, PSI.ServiceModel}()
     model_ref = ModelReference(StandardPTDFForm, devices, branches, services);
     parameters_value = [true, false]
+    systems = [c_sys5, c_sys14]
+    PTDF_ref = Dict{PSY.System, PSY.PTDF}(c_sys5 => PTDF5, c_sys14 => PTDF14)
+    test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
+                                             c_sys14 => 120000.0)
 
-    for p in parameters_value
+    for sys in systems, p in parameters_value
         @info("Testing ED StandardPTDFForm solve")
         @testset "ED StandardPTDFForm model parameters = $(p)" begin
-        #ED = OperationModel(TestOptModel, model_ref, c_sys5; PTDF = PTDF5, optimizer = GLPK_optimizer, parameters = p)
-        #res_5 = solve_op_model!(ED)
-        #@test termination_status(ED.canonical_model.JuMPmodel) == MOI.OPTIMAL
-        #@test isapprox(res_5.total_cost[:OBJECTIVE_FUNCTION], 240000, atol = 10000)
-        #14 Bus Test
-        ED = OperationModel(TestOptModel, model_ref, c_sys14; PTDF = PTDF14, optimizer = OSQP_optimizer, parameters = p);
-        res_14 = solve_op_model!(ED)
+        ED = OperationModel(TestOptModel, model_ref, sys; PTDF = PTDF_ref[sys], optimizer = OSQP_optimizer, parameters = p)
+        res = solve_op_model!(ED)
         @test termination_status(ED.canonical_model.JuMPmodel) == MOI.OPTIMAL
-        @test isapprox(res_14.total_cost[:OBJECTIVE_FUNCTION], 120000, atol = 15000)
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 10000)
         end
     end
 end
 
-
-@testset "Solving ED With PowerModels Networks" begin
-    devices = Dict{Symbol, DeviceModel}(:Generators => DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch),
-                                        :Loads =>  DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad))
-    branches5 = Dict{Symbol, DeviceModel}(:L => DeviceModel(PSY.Line, PSI.ACSeriesBranch))
-    branches14 = Dict{Symbol, DeviceModel}(:L => DeviceModel(PSY.Line, PSI.ACSeriesBranch),
-                                           :T => DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch),
-                                           :TT => DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch))
-    services = Dict{Symbol, PSI.ServiceModel}()
+@testset "Solving ED With PowerModels with loss-less convex models" begin
+    systems = [c_sys5, c_sys14]
     parameters_value = [true, false]
     networks = [PM.DCPlosslessForm,
-                PM.NFAForm,
-                PM.StandardACPForm,
-                #PM.StandardACRForm,
-                PM.StandardACTForm,
-                PM.StandardDCPLLForm,
-                PM.AbstractLPACCForm,
-                PM.SOCWRForm,
-                PM.QCWRForm,
-                PM.QCWRTriForm]
+                PM.NFAForm]
+    test_results = Dict{PSY.System, Float64}(c_sys5 => 320000.0,  
+                                             c_sys14 => 140000.0)
 
-    for  net in networks, p in parameters_value
+    for  net in networks, p in parameters_value, sys in systems
         @info("Testing ED $(net) solve")
         @testset "ED model $(net) and parameters = $(p)" begin
-        model_ref5 = ModelReference(net, devices, branches5, services);
-        #ED = OperationModel(TestOptModel, model_ref5, c_sys5; optimizer = ipopt_optimizer, parameters = p)
-        #res_5 = solve_op_model!(ED)
-        #@test isapprox(res_5.total_cost[:OBJECTIVE_FUNCTION], 325000, atol = 25000)
-        #@test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
-        #14 Bus Test
-        model_ref14 = ModelReference(net, devices, branches14, services);
-        ED = OperationModel(TestOptModel, model_ref14, c_sys14; optimizer = ipopt_optimizer, parameters = p);
-        res_14 = solve_op_model!(ED)
-        @test isapprox(res_14.total_cost[:OBJECTIVE_FUNCTION], 120000, atol = 10000)
+        model_ref = ModelReference(net, devices, branches, services);
+        ED = OperationModel(TestOptModel, model_ref, sys; optimizer = OSQP_optimizer, parameters = p);
+        res = solve_op_model!(ED)
+        #The tolerance range here is large because NFA has a much lower objective value
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 25000)
+        @test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL]
+        end
+    end
+
+end
+
+@testset "Solving ED With PowerModels with loss-less convex models" begin
+    systems = [c_sys5, c_sys14]
+    parameters_value = [true, false]
+    networks = [PM.StandardDCPLLForm, 
+                PM.AbstractLPACCForm]
+    test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
+                                             c_sys14 => 140000.0)
+
+    for  net in networks, p in parameters_value, sys in systems
+        @info("Testing ED $(net) solve")
+        @testset "ED model $(net) and parameters = $(p)" begin
+        model_ref = ModelReference(net, devices, branches, services);
+        ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
+        res = solve_op_model!(ED)
+        #The tolerance range here is large because NFA has a much lower objective value
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 10000)
+        @test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
+        end
+    end
+
+end
+
+#= These tests are broken temporarily
+@testset "Solving ED With PowerModels with convex SOC and QC models" begin
+    systems = [c_sys5, c_sys14]
+    parameters_value = [true, false]
+    networks = [PM.SOCWRForm,
+                 PM.QCWRForm,
+                 PM.QCWRTriForm,]
+    test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
+                                             c_sys14 => 140000.0)
+
+    for  net in networks, p in parameters_value, sys in systems
+        @info("Testing ED $(net) solve")
+        @testset "ED model $(net) and parameters = $(p)" begin
+        model_ref = ModelReference(net, devices, branches, services);
+        ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
+        res = solve_op_model!(ED)
+        #The tolerance range here is large because NFA has a much lower objective value
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 10000)
+        @test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
+        end
+    end
+
+end
+=#
+
+
+@testset "Solving ED With PowerModels Non-Convex Networks" begin
+    systems = [c_sys5, c_sys14]
+    parameters_value = [true, false]
+    networks = [PM.StandardACPForm,
+                PM.StandardACRForm,
+                PM.StandardACTForm]
+        test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
+                                             c_sys14 => 140000.0)
+
+    for  net in networks, p in parameters_value, sys in systems
+        @info("Testing ED $(net) solve")
+        @testset "ED model $(net) and parameters = $(p)" begin
+        model_ref = ModelReference(net, devices, branches, services);
+        ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
+        res = solve_op_model!(ED)
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 10000)
         @test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
         end
     end
@@ -93,11 +136,6 @@ end
 @testset "Solving UC Linear Networks" begin
     devices = Dict{Symbol, DeviceModel}(:Generators => DeviceModel(PSY.ThermalStandard, PSI.ThermalUnitCommitment),
                                         :Loads =>  DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad))
-    branches5 = Dict{Symbol, DeviceModel}(:L => DeviceModel(PSY.Line, PSI.ACSeriesBranch))
-    branches14 = Dict{Symbol, DeviceModel}(:L => DeviceModel(PSY.Line, PSI.ACSeriesBranch),
-                                           :T => DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch),
-                                           :TT => DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch))
-    services = Dict{Symbol, PSI.ServiceModel}()
     parameters_value = [true, false]
     networks = [PM.DCPlosslessForm,
                 PM.NFAForm,

--- a/test/operation_model_solve.jl
+++ b/test/operation_model_solve.jl
@@ -28,7 +28,7 @@ end
     systems = [c_sys5, c_sys14]
     PTDF_ref = Dict{PSY.System, PSY.PTDF}(c_sys5 => PTDF5, c_sys14 => PTDF14)
     test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
-                                             c_sys14 => 120000.0)
+                                             c_sys14 => 140000.0)
 
     for sys in systems, p in parameters_value
         @info("Testing ED StandardPTDFForm solve")
@@ -53,11 +53,11 @@ end
         @info("Testing ED $(net) solve")
         @testset "ED model $(net) and parameters = $(p)" begin
         model_ref = ModelReference(net, devices, branches, services);
-        ED = OperationModel(TestOptModel, model_ref, sys; optimizer = OSQP_optimizer, parameters = p);
+        ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
         res = solve_op_model!(ED)
         #The tolerance range here is large because NFA has a much lower objective value
         @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 25000)
-        @test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL]
+        @test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
         end
     end
 
@@ -85,14 +85,13 @@ end
 
 end
 
-#= These tests are broken temporarily
 @testset "Solving ED With PowerModels with convex SOC and QC models" begin
     systems = [c_sys5, c_sys14]
     parameters_value = [true, false]
     networks = [PM.SOCWRForm,
                  PM.QCWRForm,
                  PM.QCWRTriForm,]
-    test_results = Dict{PSY.System, Float64}(c_sys5 => 340000.0,  
+    test_results = Dict{PSY.System, Float64}(c_sys5 => 320000.0,  
                                              c_sys14 => 140000.0)
 
     for  net in networks, p in parameters_value, sys in systems
@@ -101,15 +100,13 @@ end
         model_ref = ModelReference(net, devices, branches, services);
         ED = OperationModel(TestOptModel, model_ref, sys; optimizer = ipopt_optimizer, parameters = p);
         res = solve_op_model!(ED)
-        #The tolerance range here is large because NFA has a much lower objective value
-        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 10000)
+        #The tolerance range here is large because Relaxations have a lower objective value
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], test_results[sys], atol = 25000)
         @test termination_status(ED.canonical_model.JuMPmodel) in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
         end
     end
 
 end
-=#
-
 
 @testset "Solving ED With PowerModels Non-Convex Networks" begin
     systems = [c_sys5, c_sys14]
@@ -137,76 +134,21 @@ end
     devices = Dict{Symbol, DeviceModel}(:Generators => DeviceModel(PSY.ThermalStandard, PSI.ThermalUnitCommitment),
                                         :Loads =>  DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad))
     parameters_value = [true, false]
+    systems = [c_sys5]
     networks = [PM.DCPlosslessForm,
                 PM.NFAForm,
                 StandardPTDFForm,
                 CopperPlatePowerModel]
 
-    for  net in networks, p in parameters_value
+    for  net in networks, p in parameters_value, sys in systems
         @info("Testing UC $(net) solve")
         @testset "UC model $(net) and parameters = $(p)" begin
-        model_ref5 = ModelReference(net, devices, branches5, services);
-        UC = OperationModel(TestOptModel, model_ref5, c_sys5; PTDF = PTDF5, optimizer = GLPK_optimizer, parameters = p)
-        res_5 = solve_op_model!(UC)
+        model_ref= ModelReference(net, devices, branches, services);
+        UC = OperationModel(TestOptModel, model_ref, sys; PTDF = PTDF5, optimizer = GLPK_optimizer, parameters = p)
+        res = solve_op_model!(UC)
         @test termination_status(UC.canonical_model.JuMPmodel) == MOI.OPTIMAL
-        if net != CopperPlatePowerModel
-            @test isapprox(res_5.total_cost[:OBJECTIVE_FUNCTION], 340000, atol = 100000)
-        else
-            @test isapprox(res_5.total_cost[:OBJECTIVE_FUNCTION], 240000, atol = 100000)
-
-        end
+        @test isapprox(res.total_cost[:OBJECTIVE_FUNCTION], 340000, atol = 100000)
         end
     end
 
 end
-
-#=
-@testset "Test the equivelance of 5bus PM and PSI models" begin
-     file = joinpath(dirname(dirname(pathof(PowerModels))),"test/data/matpower/case5.m")
-     #ps5 = PowerSystems.parsestandardfiles(file) # this fails because PSY changes to mixed_units
-
-     # adjusted standard file parsing without mixed units
-     ps5 = PowerSystems.parse_file(file)
-     #make_mixed_units(ps5)
-     ps5 = PowerSystems.pm2ps_dict(ps5)
-     # a single period simulation should be equivelant to a PM simulation
-     for (k,l) in ps5["load"]
-         l["scalingfactor"] = l["scalingfactor"][1]
-     end
-     bus5, gen5, stor5, branch5,load5,lz5,shunts5,service5 = ps_dict2ps_struct(ps5)
-     sys5 = PSY.System(bus5,gen5,load5,branch5,stor5,100.0)
-     ED5 = EconomicDispatch(sys5, PM.DCPlosslessForm; optimizer = ipopt_optimizer)
-     res_5 = solve_op_model!(ED5)
-
-     pm5 = PowerModels.parse_file(file)
-     PM5 = build_generic_model(pm5,DCPPowerModel,PowerModels.post_opf)
-     res_PM5 = solve_generic_model(PM5,ipopt_optimizer)
-
-    @test isapprox(res_5.total_cost[:OBJECTIVE_FUNCTION], res_PM5["objective"],atol = 1)
- end
-
-  @testset "Test the equivelance of 14bus PM and PSI models" begin
-     file = joinpath(dirname(dirname(pathof(PowerModels))),"test/data/matpower/case14.m")
-     #ps14 = PowerSystems.parsestandardfiles(file) # this fails because PSY changes to mixed_units
-
-      # adjusted stndard file parsing without mixed units
-     ps14 = PowerSystems.parse_file(file)
-     #make_mixed_units(ps14)
-     ps14 = PowerSystems.pm2ps_dict(ps14)
-
-      # a single period simulation should be equivelant to a PM simulation
-     for (k,l) in ps14["load"]
-         l["scalingfactor"] = l["scalingfactor"][1]
-     end
-     bus14, gen14, stor14, branch14,load14,lz14,shunts14,service14 = ps_dict2ps_struct(ps14)
-     sys14 = PSY.System(bus14,gen14,load14,branch14,stor14,100.0)
-     ED14 = EconomicDispatch(sys14, PM.DCPlosslessForm; optimizer = ipopt_optimizer)
-     res_14 = solve_op_model!(ED14)
-
-      pm14 = PowerModels.parse_file(file)
-     PM14 = build_generic_model(pm14,DCPPowerModel,PowerModels.post_opf)
-     res_PM14 = solve_generic_model(PM14,ipopt_optimizer)
-
-      @test isapprox(res_14.total_cost[:OBJECTIVE_FUNCTION], res_PM14["objective"], atol = 1)
- end
- =#

--- a/test/renewable_generation_constructors.jl
+++ b/test/renewable_generation_constructors.jl
@@ -2,16 +2,16 @@
     # See https://discourse.julialang.org/t/how-to-use-test-warn/15557/5 about testing for warning throwing
     warn_message = "The data doesn't devices of type RenewableDispatch, consider changing the device models"
     model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableFullDispatch)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps,)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps,)
     @test_logs (:warn, warn_message) construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5); parameters = true);
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     @test_logs (:warn, warn_message) construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5); parameters = true);
 end
 
 @testset "Renewable DCPLossLess FullDispatch" begin
     model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableFullDispatch)
     #5 Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -21,7 +21,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
@@ -32,7 +32,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Forecast Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); forecast = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -42,7 +42,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Forecast - No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false, forecast = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
@@ -55,13 +55,13 @@ end
 end
 
 @testset "Renewable ACPPower Full Dispatch (Broken, Missing data)" begin
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     #construct_device!(ps_model, PSY.RenewableDispatch, PSI.RenewableFullDispatch, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5));
 end
 
 @testset "Renewable DCPLossLess ConstantPowerFactor" begin
     model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableConstantPowerFactor)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -71,7 +71,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
@@ -82,7 +82,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Forecast Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); forecast = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -92,7 +92,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Forecast - No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false, forecast = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
@@ -106,7 +106,7 @@ end
 
 @testset "Renewable ACP ConstantPowerFactor" begin
     model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableConstantPowerFactor)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 144
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -116,7 +116,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 144
@@ -127,7 +127,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Forecast Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5); forecast = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 144
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -137,7 +137,7 @@ end
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
     # No Forecast - No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false, forecast = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 144
@@ -151,14 +151,14 @@ end
 
 @testset "Renewable DCPLossLess FixedOutput" begin
     model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableFixed)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
@@ -166,14 +166,14 @@ end
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Forecast Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); forecast = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Forecast - No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false, forecast = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
@@ -184,14 +184,14 @@ end
 
 @testset "Renewable ACP FixedOutput" begin
     model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableFixed)
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
@@ -199,14 +199,14 @@ end
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Forecast Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5); forecast = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.GreaterThan{Float64}) == 0
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.EqualTo{Float64}) == 0
     # No Forecast - No Parameters Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5_re, time_steps, Dates.Minute(5); parameters = false, forecast = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 0

--- a/test/rts_system_tests.jl
+++ b/test/rts_system_tests.jl
@@ -1,0 +1,68 @@
+#= @testset "RTS construction test set" begin
+    networks = [PSI.CopperPlatePowerModel,
+                PSI.StandardPTDFForm,
+                PM.DCPlosslessForm,
+                PM.NFAForm,
+                PM.StandardACPForm,
+                PM.StandardACRForm,
+                PM.StandardACTForm,
+                PM.StandardDCPLLForm,
+                PM.AbstractLPACCForm,
+                PM.SOCWRForm,
+                PM.QCWRForm,
+                PM.QCWRTriForm]
+
+    thermal_gens = [PSI.ThermalUnitCommitment,
+                    PSI.ThermalDispatch,
+                    PSI.ThermalRampLimited,
+                    PSI.ThermalDispatchNoMin]
+
+    systems = [c_sys5,
+               c_sys5_re,
+               c_sys5_bat];
+
+    renewable_curtailment_model = DeviceModel(PSY.RenewableDispatch, PSI.RenewableConstantPowerFactor)
+    thermal_model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch)
+    hvdc_model = DeviceModel(PSY.HVDCLine, PSI.DCSeriesBranch)
+    #hydro = DeviceModel(PSY.HydroDispatch, PSI.HydroDispatch)
+    transformer_model = DeviceModel(PSY.Transformer2W, PSI.ACSeriesBranch)
+    tap_transformer_model = DeviceModel(PSY.TapTransformer, PSI.ACSeriesBranch)
+    renewable_fix = DeviceModel(PSY.RenewableFix, PSI.RenewableFixed)
+    load_model = DeviceModel(PSY.PowerLoad, PSI.StaticPowerLoad)
+    line_model = DeviceModel(PSY.Line, PSI.ACSeriesBranch)
+    bat = DeviceModel(PSY.GenericBattery, PSI.BookKeeping)
+
+    devices = Dict{Symbol, DeviceModel}(:Generators => thermal_model,
+                                    :Loads =>  load_model,
+                                    :rc => renewable_curtailment_model,
+                                    :ren_fix => renewable_fix)
+    branches = Dict{Symbol, DeviceModel}(:Lines => line_model,
+                                    :HVDC => hvdc_model,
+                                    :tap_trafo => tap_transformer_model,
+                                    :trafo => transformer_model)
+    services = Dict{Symbol, PSI.ServiceModel}()
+    net = PSI.CopperPlatePowerModel
+
+
+    for net in networks, thermal in thermal_gens, system in systems
+        @testset "Operation Model $(net) - $(thermal) - $(system)" begin
+            thermal_model = DeviceModel(PSY.ThermalStandard, thermal)
+            devices = Dict{Symbol, DeviceModel}(:Generators => thermal_model, :Loads =>  load_model)
+            branches = Dict{Symbol, DeviceModel}(:Lines => line_model, :Transformer)
+            services = Dict{Symbol, PSI.ServiceModel}()
+            op_model = OperationModel(TestOptModel, net,
+                                        devices,
+                                        branches,
+                                        services,
+                                        system;
+                                        parameters = false,
+                                        PTDF = PTDF5)
+        @test :nodal_balance_active in keys(op_model.canonical_model.expressions)
+        @test !(:params in keys(op_model.canonical_model.JuMPmodel.ext))
+        end
+
+
+    end
+
+end
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,20 +25,20 @@ OSQP_optimizer = JuMP.with_optimizer(OSQP.Optimizer, verbose = false)
 include("test_utils/get_test_data.jl")
 
 @testset "Common Functionalities" begin
-    #include("base_structs.jl")
+    include("base_structs.jl")
     #include("PowerModels_interface.jl")
 end
 
 @testset "Device Constructors" begin
-    #include("thermal_generation_constructors.jl")
-    #include("renewable_generation_constructors.jl")
-    #include("load_constructors.jl")
-    #include("storage_constructors.jl")
+    include("thermal_generation_constructors.jl")
+    include("renewable_generation_constructors.jl")
+    include("load_constructors.jl")
+    include("storage_constructors.jl")
     #include("hydro_generation_constructors.jl")
 end
 
 @testset "Network Constructors" begin
-   #include("network_constructors.jl")
+   include("network_constructors.jl")
 end
 
 @testset "Services Constructors" begin
@@ -46,6 +46,6 @@ end
 end
 
 @testset "Operation Models" begin
-    #include("operation_model_constructor.jl")
+    include("operation_model_constructor.jl")
     include("operation_model_solve.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ end
 end
 
 @testset "Network Constructors" begin
-    include("network_constructors.jl")
+   #include("network_constructors.jl")
 end
 
 @testset "Services Constructors" begin
@@ -47,5 +47,5 @@ end
 
 @testset "Operation Models" begin
     #include("operation_model_constructor.jl")
-    #include("operation_model_solve.jl")
+    include("operation_model_solve.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,15 +30,15 @@ include("test_utils/get_test_data.jl")
 end
 
 @testset "Device Constructors" begin
-    include("thermal_generation_constructors.jl")
-    include("renewable_generation_constructors.jl")
-    include("load_constructors.jl")
-    include("storage_constructors.jl")
+    #include("thermal_generation_constructors.jl")
+    #include("renewable_generation_constructors.jl")
+    #include("load_constructors.jl")
+    #include("storage_constructors.jl")
     #include("hydro_generation_constructors.jl")
 end
 
 @testset "Network Constructors" begin
-    #include("network_constructors.jl")
+    include("network_constructors.jl")
 end
 
 @testset "Services Constructors" begin

--- a/test/storage_constructors.jl
+++ b/test/storage_constructors.jl
@@ -1,7 +1,7 @@
 @testset "Storage Basic Storage With DC - PF" begin
     model = DeviceModel(PSY.GenericBattery, PSI.BookKeeping)
     network = PM.DCPlosslessForm
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0,  nothing, network, time_steps)
     construct_device!(ps_model, model, network, c_sys5_bat, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 72
     @test JuMP.num_constraints(ps_model.JuMPmodel,GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
@@ -13,7 +13,7 @@ end
 @testset "Storage Basic Storage With AC - PF" begin
     model = DeviceModel(PSY.GenericBattery, PSI.BookKeeping)
     network = PM.StandardACPForm
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0,  nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, network, c_sys5_bat, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 96
     @test JuMP.num_constraints(ps_model.JuMPmodel,GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 0
@@ -25,7 +25,7 @@ end
 @testset "Storage with Reservation DC - PF" begin
 model = DeviceModel(PSY.GenericBattery, PSI.BookKeepingwReservation)
     network = PM.DCPlosslessForm
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0,  nothing, network, time_steps)
     construct_device!(ps_model, model, network, c_sys5_bat, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 96
     @test JuMP.num_constraints(ps_model.JuMPmodel,GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 48
@@ -38,7 +38,7 @@ end
 @testset "Storage with Reservation With AC - PF" begin
     model = DeviceModel(PSY.GenericBattery, PSI.BookKeepingwReservation)
     network = PM.StandardACPForm
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, network, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0,  nothing, network, time_steps)
     construct_device!(ps_model, model, network, c_sys5_bat, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,GenericAffExpr{Float64,VariableRef},MOI.LessThan{Float64}) == 48

--- a/test/test_utils/get_test_data.jl
+++ b/test/test_utils/get_test_data.jl
@@ -25,7 +25,7 @@ sys5_bat = PSY._System(nodes5, thermal_generators5, loads5, branches5, battery5,
 c_sys5_bat = PSY.System(sys5_bat)
 
 # RTS Data
-RTS_GMLC_DIR = joinpath(DATA_DIR, "RTS_GMLC")
-cdm_dict = PSY.csv2ps_dict(RTS_GMLC_DIR, 100.0);
-sys_rts = PSY._System(cdm_dict);
-c_rts = PSY.System(sys_rts);
+#RTS_GMLC_DIR = joinpath(DATA_DIR, "RTS_GMLC")
+#cdm_dict = PSY.csv2ps_dict(RTS_GMLC_DIR, 100.0);
+#sys_rts = PSY._System(cdm_dict);
+#c_rts = PSY.System(sys_rts);

--- a/test/test_utils/get_test_data.jl
+++ b/test/test_utils/get_test_data.jl
@@ -4,8 +4,6 @@ base_dir = string(dirname(dirname(pathof(PowerSystems))));
 DATA_DIR = joinpath(base_dir, "data")
 include(joinpath(base_dir,"data/data_5bus_pu.jl"));
 include(joinpath(base_dir,"data/data_14bus_pu.jl"))
-bus_numbers5 = [b.number for b in nodes5]
-bus_numbers14 = [b.number for b in nodes14];
 
 #Base Systems
 sys5 = PSY._System(nodes5, thermal_generators5, loads5, branches5, nothing,  100.0, forecasts5, nothing, nothing);
@@ -14,7 +12,8 @@ c_sys5 = PSY.System(sys5)
 c_sys14 = PSY.System(sys14)
 PTDF5 = PSY.PTDF(branches5, nodes5);
 PTDF14 = PSY.PTDF(branches14, nodes14);
-
+buses5 = PSY.get_components(PSY.Bus, c_sys5)
+buses14 = PSY.get_components(PSY.Bus, c_sys14)
 
 #System with Renewable Energy
 sys5_re = PSY._System(nodes5, vcat(thermal_generators5, renewable_generators5), loads5, branches5, nothing,  100.0, forecasts5, nothing, nothing);

--- a/test/thermal_generation_constructors.jl
+++ b/test/thermal_generation_constructors.jl
@@ -4,7 +4,7 @@
     uc_constraint_names = [:ramp_ThermalStandard_up, :ramp_ThermalStandard_down, :duration_ThermalStandard_up, :duration_ThermalStandard_down]
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalUnitCommitment)
     #5-Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 480
@@ -24,7 +24,7 @@
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5); parameters = true);
     @test (:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 480
@@ -45,7 +45,7 @@
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14-Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 480
@@ -65,7 +65,7 @@
     JuMP.@objective(ps_model.JuMPmodel, Min, ps_model.cost_function)
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5); parameters = true);
     @test (:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 480
@@ -91,7 +91,7 @@ end
     uc_constraint_names = [:ramp_ThermalStandard_up, :ramp_ThermalStandard_down, :duration_ThermalStandardl_up, :duration_ThermalStandard_down]
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalUnitCommitment)
     #5-Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 600
@@ -108,7 +108,7 @@ end
     end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5); parameters = true);
     @test (:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 600
@@ -126,7 +126,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14-Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5); parameters = false);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 600
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -145,7 +145,7 @@ end
     end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = true)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5); parameters = true);
     @test JuMP.num_variables(ps_model.JuMPmodel) == 600
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 0
@@ -171,7 +171,7 @@ end
 @testset "Thermal Dispatch With DC - PF" begin
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch)
     #5-Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -182,7 +182,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
@@ -195,7 +195,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14-Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -206,7 +206,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
@@ -222,7 +222,7 @@ end
 @testset "Thermal Dispatch With AC - PF" begin
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatch)
     #5 Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -233,7 +233,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
@@ -246,7 +246,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14 Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -257,7 +257,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
@@ -275,7 +275,7 @@ end
 @testset "Thermal Dispatch No-Minimum With DC - PF" begin
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatchNoMin)
     #5 Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -290,7 +290,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
@@ -306,7 +306,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14 Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -321,7 +321,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
@@ -340,7 +340,7 @@ end
 @testset "Thermal Dispatch No-Minimum With AC - PF" begin
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalDispatchNoMin)
     #5 Bus testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -354,7 +354,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
@@ -370,7 +370,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14 Bus Testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -384,7 +384,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5); parameters = false);
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
@@ -406,7 +406,7 @@ end
     ramp_constraint_names = [:ramp_ThermalStandard_up, :ramp_ThermalStandard_down]
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalRampLimited)
     #5 Bus Testing with 5 - Min simulation time
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -418,7 +418,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #5 Bus Testing with 1 Hour Simulation Time
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Hour(1));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -430,7 +430,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #5 Bus Testing with 2 Hour Simulation Time
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Hour(2));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -441,7 +441,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
@@ -454,7 +454,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14 Bus Testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 240
@@ -468,7 +468,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.StandardACPForm, c_sys14, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 240
@@ -488,7 +488,7 @@ end
     ramp_constraint_names = [:ramp_ThermalStandard_up, :ramp_ThermalStandard_down]
     model = DeviceModel(PSY.ThermalStandard, PSI.ThermalRampLimited)
     #5 Bus Testing
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -502,7 +502,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers5, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses5, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys5, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
@@ -518,7 +518,7 @@ end
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericAffExpr{Float64,VariableRef}
 
     #14 Bus Testing
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5));
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120
     @test JuMP.num_constraints(ps_model.JuMPmodel,JuMP.GenericAffExpr{Float64,VariableRef},MOI.Interval{Float64}) == 120
@@ -532,7 +532,7 @@ end
     @test  !((VariableRef, MOI.ZeroOne) in JuMP.list_of_constraint_types(ps_model.JuMPmodel))
     @test JuMP.objective_function_type(ps_model.JuMPmodel) == JuMP.GenericQuadExpr{Float64,VariableRef}
 
-    ps_model = PSI._canonical_model_init(bus_numbers14, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
+    ps_model = PSI._canonical_model_init(buses14, 100.0, nothing, PM.AbstractPowerFormulation, time_steps; parameters = false)
     construct_device!(ps_model, model, PM.DCPlosslessForm, c_sys14, time_steps, Dates.Minute(5); parameters = false)
     @test !(:params in keys(ps_model.JuMPmodel.ext))
     @test JuMP.num_variables(ps_model.JuMPmodel) == 120


### PR DESCRIPTION
This PR updates the interface of PowerSimulations with PowerModels to address the requirements of some users to have access to the flow variables.  

In Summary. 

- Creates a PowerSimulations reduced version of `core_ref!` 
- Substitutes `build_generic_model` with a model instantiation 
- Changes the creation of the line flow variables in order to reference them in the PowerSimulations model and the PowerModels model. 
- implements #105 partially for some variables
- Updates the testing  

closes #148 