### PR TITLE
Fix Optimizer log printing

### DIFF
--- a/src/core/build_simulations.jl
+++ b/src/core/build_simulations.jl
@@ -133,8 +133,8 @@ function _feedforward_rule_check(synch::Synchronize,
     to_stage_count = get_execution_count(to_stage)
     to_stage_synch = synch.to_steps
     from_stage_synch = synch.from_steps
-
-    if from_stage_synch < from_stage_horizon
+    
+    if from_stage_synch > from_stage_horizon
         error("The lookahead length $(from_stage_horizon) in stage is insufficient to synchronize with $(from_stage_synch) feedforward steps")
     end
 

--- a/src/routines/write_model.jl
+++ b/src/routines/write_model.jl
@@ -81,7 +81,7 @@ function _export_optimizer_log(optimizer_log::Dict{Symbol, Any},
         optimizer_log[:solve_time] = MOI.get(canonical_model.JuMPmodel, MOI.SolveTime())
     catch
         @warn("SolveTime() property not supported by the Solver")
-        optimizer_log[:solve_time] = nothing #"Not Supported by solver"
+        optimizer_log[:solve_time] = NaN #"Not Supported by solver"
     end
     _write_optimizer_log(optimizer_log, path)
     return

--- a/src/simulation_models/stage_update.jl
+++ b/src/simulation_models/stage_update.jl
@@ -104,7 +104,7 @@ function _calculate_ic_quantity(initial_condition_key::ICKey{TimeDurationOFF, PS
     current_counter = time_cache[:count]
     last_status = time_cache[:status]
     var_status = var_value > eps() ? 1.0 : 0.0
-    @assert last_status == var_status
+    @assert abs(last_status - var_status) < eps()
 
     if last_status >= 1.0
         return current_counter
@@ -126,7 +126,7 @@ function _calculate_ic_quantity(initial_condition_key::ICKey{TimeDurationON, PSD
     current_counter = time_cache[:count]
     last_status = time_cache[:status]
     var_status = var_value > eps() ? 1.0 : 0.0
-    @assert last_status == var_status
+    @assert abs(last_status - var_status) < eps()
 
     if last_status >= 1.0
         return 0.0


### PR DESCRIPTION
- Fixes the Issue when Solver doesn't support SolveTime() and adds NaN to the Optimizer_log feather file instead of a Nothing