### PR TITLE
Device timeseries

### DIFF
--- a/src/devices_models/device_model.jl
+++ b/src/devices_models/device_model.jl
@@ -49,4 +49,4 @@ mutable struct DeviceModel{D<:PSY.Device,
 end
 
 get_feed_forward(m::DeviceModel) = m.feed_forward
-get_services(m::DeviceModel) = m.services
+get_services(m::Union{DeviceModel,Nothing}) = isnothing(m) ? nothing : m.services

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -39,25 +39,20 @@ function branch_rate_bounds!(psi_container::PSIContainer,
                                 devices::IS.FlattenIteratorWrapper{B},
                                 ::Type{<:AbstractBranchFormulation},
                                 ::Type{<:PM.AbstractDCPModel}) where {B<:PSY.ACBranch}
-    names = Vector{String}(undef, length(devices))
-    limit_values = Vector{MinMax}(undef, length(devices))
-    additional_terms_ub = Vector{Vector{Symbol}}(undef, length(devices))
-    additional_terms_lb = Vector{Vector{Symbol}}(undef, length(devices))
+    constraint_data = Dict{String, DeviceRange}()
 
-    for (ix, d) in enumerate(devices)
-        limit_values[ix] = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
-        names[ix] = PSY.get_name(d)
+    for d in devices
+        limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
+        name = PSY.get_name(d)
         services_ub = Vector{Symbol}()
-        services_lb = Vector{Symbol}()
         for service in PSY.get_services(d)
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        additional_terms_ub[ix] = services_ub
-        additional_terms_lb[ix] = services_lb
+        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
     end
     set_variable_bounds(psi_container,
-                        DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                        constraint_data,
                         Symbol("Fp_$(B)"))
     return
 end
@@ -66,29 +61,24 @@ function branch_rate_bounds!(psi_container::PSIContainer,
                             devices::IS.FlattenIteratorWrapper{B},
                             ::Type{<:AbstractBranchFormulation},
                             ::Type{<:PM.AbstractActivePowerModel}) where B<:PSY.ACBranch
-    names = Vector{String}(undef, length(devices))
-    limit_values = Vector{MinMax}(undef, length(devices))
-    additional_terms_ub = Vector{Vector{Symbol}}(undef, length(devices))
-    additional_terms_lb = Vector{Vector{Symbol}}(undef, length(devices))
+    constraint_data = Dict{String, DeviceRange}()
 
-    for (ix, d) in enumerate(devices)
-        limit_values[ix] = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
-        names[ix] = PSY.get_name(d)
+    for d in devices
+        limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
+        name = PSY.get_name(d)
         services_ub = Vector{Symbol}()
-        services_lb = Vector{Symbol}()
         for service in PSY.get_services(d)
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        additional_terms_ub[ix] = services_ub
-        additional_terms_lb[ix] = services_lb
+        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
     end
     set_variable_bounds(psi_container,
-                        DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                        constraint_data,
                         Symbol("FpFT_$(B)"))
 
     set_variable_bounds(psi_container,
-                        DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                        constraint_data,
                         Symbol("FpTF_$(B)"))
     return
 end
@@ -99,29 +89,24 @@ function branch_rate_bounds!(psi_container::PSIContainer,
                                 ::Type{S}) where {B<:PSY.ACBranch,
                                                   D<:AbstractBranchFormulation,
                                                   S<:PM.AbstractPowerModel}
-    names = Vector{String}(undef, length(devices))
-    limit_values = Vector{MinMax}(undef, length(devices))
-    additional_terms_ub = Vector{Vector{Symbol}}(undef, length(devices))
-    additional_terms_lb = Vector{Vector{Symbol}}(undef, length(devices))
+    constraint_data = Dict{String, DeviceRange}()
 
-    for (ix, d) in enumerate(devices)
-        limit_values[ix] = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
-        names[ix] = PSY.get_name(d)
+    for d in devices
+        limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
+        name = PSY.get_name(d)
         services_ub = Vector{Symbol}()
-        services_lb = Vector{Symbol}()
         for service in PSY.get_services(d)
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        additional_terms_ub[ix] = services_ub
-        additional_terms_lb[ix] = services_lb
+        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
     end
     set_variable_bounds(psi_container,
-                        DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                        constraint_data,
                         Symbol("FpFT_$(B)"))
 
     set_variable_bounds(psi_container,
-                        DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                        constraint_data,
                         Symbol("FpTF_$(B)"))
     return
 end
@@ -134,26 +119,21 @@ function branch_rate_constraints!(psi_container::PSIContainer,
                                 feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {B<:PSY.ACBranch,
                                                   D<:AbstractBranchFormulation,
                                                   S<:PM.AbstractDCPModel}
-    names = Vector{String}(undef, length(devices))
-    limit_values = Vector{MinMax}(undef, length(devices))
-    additional_terms_ub = Vector{Vector{Symbol}}(undef, length(devices))
-    additional_terms_lb = Vector{Vector{Symbol}}(undef, length(devices))
+    constraint_data = Dict{String, DeviceRange}()
 
-    for (ix, d) in enumerate(devices)
-        limit_values[ix] = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
-        names[ix] = PSY.get_name(d)
+    for d in devices
+        limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
+        name = PSY.get_name(d)
         services_ub = Vector{Symbol}()
-        services_lb = Vector{Symbol}()
         for service in PSY.get_services(d)
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        additional_terms_ub[ix] = services_ub
-        additional_terms_lb[ix] = services_lb
+        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
     end
 
     device_range(psi_container,
-                 DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                 constraint_data,
                  Symbol("RateLimit_$(B)"),
                  Symbol("Fp_$(B)"))
     return
@@ -164,31 +144,26 @@ function branch_rate_constraints!(psi_container::PSIContainer,
                                 model::DeviceModel{B, <:AbstractBranchFormulation},
                                 ::Type{<:PM.AbstractActivePowerModel},
                                 feed_forward::Union{Nothing, AbstractAffectFeedForward}) where B<:PSY.ACBranch
-    names = Vector{String}(undef, length(devices))
-    limit_values = Vector{MinMax}(undef, length(devices))
-    additional_terms_ub = Vector{Vector{Symbol}}(undef, length(devices))
-    additional_terms_lb = Vector{Vector{Symbol}}(undef, length(devices))
+    constraint_data = Dict{String, DeviceRange}()
 
-    for (ix, d) in enumerate(devices)
-        limit_values[ix] = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
-        names[ix] = PSY.get_name(d)
+    for d in devices
+        limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
+        name = PSY.get_name(d)
         services_ub = Vector{Symbol}()
-        services_lb = Vector{Symbol}()
         for service in PSY.get_services(d)
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        additional_terms_ub[ix] = services_ub
-        additional_terms_lb[ix] = services_lb
+        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
     end
 
     device_range(psi_container,
-                 DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                 constraint_data,
                  Symbol("RateLimitFT_$(B)"),
                  Symbol("FpFT_$(B)"))
 
     device_range(psi_container,
-                 DeviceRange(names, limit_values, additional_terms_ub, additional_terms_ub),
+                 constraint_data,
                  Symbol("RateLimitTF_$(B)"),
                  Symbol("FpTF_$(B)"))
     return
@@ -246,7 +221,7 @@ function branch_flow_constraints!(psi_container::PSIContainer,
     limit_values_FT = Vector{MinMax}(undef, length(devices))
     limit_values_TF = Vector{MinMax}(undef, length(devices))
 
-    for (ix, d) in enumerate(devices)
+    for d in devices
         limit_values_FT[ix] = PSY.get_flowlimits(d)
         limit_values_TFt[ix] = (min = PSY.get_flowlimits(d).max, max = PSY.get_flowlimits(d).min)
         names[ix] = PSY.get_name(d)

--- a/src/devices_models/devices/AC_branches.jl
+++ b/src/devices_models/devices/AC_branches.jl
@@ -39,7 +39,7 @@ function branch_rate_bounds!(psi_container::PSIContainer,
                                 devices::IS.FlattenIteratorWrapper{B},
                                 ::Type{<:AbstractBranchFormulation},
                                 ::Type{<:PM.AbstractDCPModel}) where {B<:PSY.ACBranch}
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
 
     for d in devices
         limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
@@ -49,7 +49,8 @@ function branch_rate_bounds!(psi_container::PSIContainer,
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
+        push!(constraint_data, 
+              DeviceRange(name, limit_values, services_ub, Vector{Symbol}()))
     end
     set_variable_bounds(psi_container,
                         constraint_data,
@@ -61,7 +62,7 @@ function branch_rate_bounds!(psi_container::PSIContainer,
                             devices::IS.FlattenIteratorWrapper{B},
                             ::Type{<:AbstractBranchFormulation},
                             ::Type{<:PM.AbstractActivePowerModel}) where B<:PSY.ACBranch
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
 
     for d in devices
         limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
@@ -71,7 +72,8 @@ function branch_rate_bounds!(psi_container::PSIContainer,
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
+        push!(constraint_data,
+              DeviceRange(name, limit_values, services_ub, Vector{Symbol}()))
     end
     set_variable_bounds(psi_container,
                         constraint_data,
@@ -89,7 +91,7 @@ function branch_rate_bounds!(psi_container::PSIContainer,
                                 ::Type{S}) where {B<:PSY.ACBranch,
                                                   D<:AbstractBranchFormulation,
                                                   S<:PM.AbstractPowerModel}
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
 
     for d in devices
         limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
@@ -99,7 +101,8 @@ function branch_rate_bounds!(psi_container::PSIContainer,
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
+        push!(constraint_data,
+              DeviceRange(name, limit_values, services_ub, Vector{Symbol}()))
     end
     set_variable_bounds(psi_container,
                         constraint_data,
@@ -119,7 +122,7 @@ function branch_rate_constraints!(psi_container::PSIContainer,
                                 feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {B<:PSY.ACBranch,
                                                   D<:AbstractBranchFormulation,
                                                   S<:PM.AbstractDCPModel}
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
 
     for d in devices
         limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
@@ -129,7 +132,8 @@ function branch_rate_constraints!(psi_container::PSIContainer,
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
+        push!(constraint_data,
+              DeviceRange(name, limit_values, services_ub, Vector{Symbol}()))
     end
 
     device_range(psi_container,
@@ -144,7 +148,7 @@ function branch_rate_constraints!(psi_container::PSIContainer,
                                 model::DeviceModel{B, <:AbstractBranchFormulation},
                                 ::Type{<:PM.AbstractActivePowerModel},
                                 feed_forward::Union{Nothing, AbstractAffectFeedForward}) where B<:PSY.ACBranch
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
 
     for d in devices
         limit_values = (min = -1*PSY.get_rate(d), max = PSY.get_rate(d))
@@ -154,7 +158,8 @@ function branch_rate_constraints!(psi_container::PSIContainer,
             SR = typeof(service)
             push!(services_ub, Symbol("R$(PSY.get_name(service))_$SR"))
         end
-        constraint_data[name] = DeviceRange(limit_values, services_ub, Vector{Symbol}())
+        push!(constraint_data,
+              DeviceRange(name, limit_values, services_ub, Vector{Symbol}()))
     end
 
     device_range(psi_container,

--- a/src/devices_models/devices/common/add_parameters.jl
+++ b/src/devices_models/devices/common/add_parameters.jl
@@ -14,7 +14,7 @@ function include_parameters(psi_container::PSIContainer,
 end
 
 function include_parameters(psi_container::PSIContainer,
-                            ts_data::Vector{Tuple{String, Int64, Float64, Vector{Float64}}},
+                            ts_data::Dict{String, DeviceTimeSeries},
                             param_reference::UpdateRef,
                             expression_name::Symbol,
                             multiplier::Float64 = 1.0)
@@ -24,9 +24,9 @@ function include_parameters(psi_container::PSIContainer,
     time_steps = model_time_steps(psi_container)
     param = _add_param_container!(psi_container, param_reference, (r[1] for r in ts_data), time_steps)
     expr = get_expression(psi_container, expression_name)
-    for t in time_steps, r in ts_data
-        param[r[1], t] = PJ.add_parameter(psi_container.JuMPmodel, r[4][t]);
-        _add_to_expression!(expr, r[2], t, param[r[1], t], r[3] * multiplier)
+    for t in time_steps, (name, r) in ts_data
+        param[name, t] = PJ.add_parameter(psi_container.JuMPmodel, r.timeseries[t]);
+        _add_to_expression!(expr, r.bus_number, t, param[name, t], r.multiplier * multiplier)
     end
     return param
 end

--- a/src/devices_models/devices/common/add_parameters.jl
+++ b/src/devices_models/devices/common/add_parameters.jl
@@ -14,7 +14,7 @@ function include_parameters(psi_container::PSIContainer,
 end
 
 function include_parameters(psi_container::PSIContainer,
-                            ts_data::Dict{String, DeviceTimeSeries},
+                            ts_data::Vector{DeviceTimeSeries},
                             param_reference::UpdateRef,
                             expression_name::Symbol,
                             multiplier::Float64 = 1.0)
@@ -22,11 +22,11 @@ function include_parameters(psi_container::PSIContainer,
         error("Operational Model doesn't have parameters enabled. Include the keyword use_parameters=true")
     end
     time_steps = model_time_steps(psi_container)
-    param = _add_param_container!(psi_container, param_reference, (r[1] for r in ts_data), time_steps)
+    param = _add_param_container!(psi_container, param_reference, (r.name for r in ts_data), time_steps)
     expr = get_expression(psi_container, expression_name)
-    for t in time_steps, (name, r) in ts_data
-        param[name, t] = PJ.add_parameter(psi_container.JuMPmodel, r.timeseries[t]);
-        _add_to_expression!(expr, r.bus_number, t, param[name, t], r.multiplier * multiplier)
+    for t in time_steps, r in ts_data
+        param[r.name, t] = PJ.add_parameter(psi_container.JuMPmodel, r.timeseries[t]);
+        _add_to_expression!(expr, r.bus_number, t, param[r.name, t], r.multiplier * multiplier)
     end
     return param
 end

--- a/src/devices_models/devices/common/add_variable.jl
+++ b/src/devices_models/devices/common/add_variable.jl
@@ -103,13 +103,12 @@ Adds a bounds to a variable in the optimization model.
 
 """
 function set_variable_bounds(psi_container::PSIContainer,
-                            bounds::DeviceRange,
+                            bounds::Dict{String, DeviceRange},
                             var_name::Symbol)
-    for t in model_time_steps(psi_container), (ix, name) in enumerate(bounds.names)
-        bound = bounds.values[ix]
+    for t in model_time_steps(psi_container), (name, bound) in bounds
         var = psi_container.variables[var_name][name, t]
-        JuMP.set_upper_bound(var, bound.max)
-        JuMP.set_lower_bound(var, bound.min)
+        JuMP.set_upper_bound(var, bound.limits.max)
+        JuMP.set_lower_bound(var, bound.limits.min)
     end
 
 end

--- a/src/devices_models/devices/common/add_variable.jl
+++ b/src/devices_models/devices/common/add_variable.jl
@@ -103,10 +103,10 @@ Adds a bounds to a variable in the optimization model.
 
 """
 function set_variable_bounds(psi_container::PSIContainer,
-                            bounds::Dict{String, DeviceRange},
+                            bounds::Vector{DeviceRange},
                             var_name::Symbol)
-    for t in model_time_steps(psi_container), (name, bound) in bounds
-        var = psi_container.variables[var_name][name, t]
+    for t in model_time_steps(psi_container), bound in bounds
+        var = psi_container.variables[var_name][bound.name, t]
         JuMP.set_upper_bound(var, bound.limits.max)
         JuMP.set_lower_bound(var, bound.limits.min)
     end

--- a/src/devices_models/devices/common/constraints_structs.jl
+++ b/src/devices_models/devices/common/constraints_structs.jl
@@ -1,31 +1,12 @@
 """ Data Container to construct range constraints"""
 struct DeviceRange
-    names::Vector{String}
-    values::Vector{MinMax}
-    additional_terms_ub::Vector{Vector{Symbol}}
-    additional_terms_lb::Vector{Vector{Symbol}}
-end
-
-function DeviceRange(count::Int64)
-    names = Vector{String}(undef, count)
-    limit_values = Vector{MinMax}(undef, count)
-    additional_terms_ub = fill(Vector{Symbol}(), count)
-    additional_terms_lb = fill(Vector{Symbol}(), count)
-    return DeviceRange(names, limit_values, additional_terms_ub, additional_terms_lb)
+    limits::MinMax
+    additional_terms_ub::Vector{Symbol}
+    additional_terms_lb::Vector{Symbol}
 end
 
 struct DeviceTimeSeries
-    names::Vector{String}
-    bus_numbers::Vector{Int64}
-    multipliers::Vector{Float64}
-    ts_vectors::Vector{Vector{Float64}}
+    bus_number::Int64
+    multiplier::Float64
+    timeseries::Vector{Float64}
 end
-
-function DeviceTimeSeries(count::Int64)
-    names = Vector{String}(undef, count)
-    bus_numbers = Vector{Int64}(undef, count)
-    multipliers = Vector{Float64}(undef, count)
-    ts_vectors = Vector{Vector{Float64}}(undef, count)
-    return DeviceTimeSeries(names, bus_numbers, multipliers, ts_vectors)
-end
-    

--- a/src/devices_models/devices/common/constraints_structs.jl
+++ b/src/devices_models/devices/common/constraints_structs.jl
@@ -17,7 +17,7 @@ struct DeviceTimeSeries
     timeseries::Vector{Float64}
     range::Union{Nothing, DeviceRange}
     function DeviceTimeSeries(name, bus_number, multiplier, timeseries, range)
-        !isnothing(range) && @assert name == range.name
+        @assert isnothing(range) || name == range.name
         return new(name, bus_number, multiplier, timeseries, range)
     end
 end

--- a/src/devices_models/devices/common/constraints_structs.jl
+++ b/src/devices_models/devices/common/constraints_structs.jl
@@ -15,7 +15,7 @@ struct DeviceTimeSeries
     bus_number::Int64
     multiplier::Float64
     timeseries::Vector{Float64}
-    range::Union{Nothing,DeviceRange}
+    range::Union{Nothing, DeviceRange}
     function DeviceTimeSeries(name, bus_number, multiplier, timeseries, range)
         !isnothing(range) && @assert name == range.name
         return new(name, bus_number, multiplier, timeseries, range)

--- a/src/devices_models/devices/common/constraints_structs.jl
+++ b/src/devices_models/devices/common/constraints_structs.jl
@@ -13,3 +13,19 @@ function DeviceRange(count::Int64)
     additional_terms_lb = fill(Vector{Symbol}(), count)
     return DeviceRange(names, limit_values, additional_terms_ub, additional_terms_lb)
 end
+
+struct DeviceTimeSeries
+    names::Vector{String}
+    bus_numbers::Vector{Int64}
+    multipliers::Vector{Float64}
+    ts_vectors::Vector{Vector{Float64}}
+end
+
+function DeviceTimeSeries(count::Int64)
+    names = Vector{String}(undef, count)
+    bus_numbers = Vector{Int64}(undef, count)
+    multipliers = Vector{Float64}(undef, count)
+    ts_vectors = Vector{Vector{Float64}}(undef, count)
+    return DeviceTimeSeries(names, bus_numbers, multipliers, ts_vectors)
+end
+    

--- a/src/devices_models/devices/common/constraints_structs.jl
+++ b/src/devices_models/devices/common/constraints_structs.jl
@@ -16,4 +16,8 @@ struct DeviceTimeSeries
     multiplier::Float64
     timeseries::Vector{Float64}
     range::Union{Nothing,DeviceRange}
+    function DeviceTimeSeries(name, bus_number, multiplier, timeseries, range)
+        !isnothing(range) && @assert name == range.name
+        return new(name, bus_number, multiplier, timeseries, range)
+    end
 end

--- a/src/devices_models/devices/common/constraints_structs.jl
+++ b/src/devices_models/devices/common/constraints_structs.jl
@@ -1,12 +1,19 @@
 """ Data Container to construct range constraints"""
 struct DeviceRange
+    name::String
     limits::MinMax
     additional_terms_ub::Vector{Symbol}
     additional_terms_lb::Vector{Symbol}
 end
 
+function DeviceRange(name::String, limits::MinMax)
+    return DeviceRange(name, limits, Vector{Symbol}(), Vector{Symbol}())
+end
+
 struct DeviceTimeSeries
+    name::String
     bus_number::Int64
     multiplier::Float64
     timeseries::Vector{Float64}
+    range::Union{Nothing,DeviceRange}
 end

--- a/src/devices_models/devices/common/range_constraint.jl
+++ b/src/devices_models/devices/common/range_constraint.jl
@@ -1,6 +1,6 @@
 @doc raw"""
     device_range(psi_container::PSIContainer,
-                 range_data::Dict{String,DeviceRange},
+                 range_data::Dict{String, DeviceRange},
                  cons_name::Symbol,
                  var_name::Symbol)
 
@@ -25,12 +25,12 @@ where limits in range_data.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* range_data::Dict{String,DeviceRange} : contains names and vector of min/max
+* range_data::Dict{String, DeviceRange} : contains names and vector of min/max
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the continuous variable
 """
 function device_range(psi_container::PSIContainer,
-                      range_data::Dict{String,DeviceRange},
+                      range_data::Dict{String, DeviceRange},
                       cons_name::Symbol,
                       var_name::Symbol)
     time_steps = model_time_steps(psi_container)
@@ -61,7 +61,7 @@ end
 
 @doc raw"""
     device_semicontinuousrange(psi_container::PSIContainer,
-                                    range_data::Dict{String,DeviceRange},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     binvar_name::Symbol)
@@ -91,13 +91,13 @@ where limits in range_data.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* range_data::Dict{String,DeviceRange} : contains names and vector of min/max
+* range_data::Dict{String, DeviceRange} : contains names and vector of min/max
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the continuous variable
 * binvar_name::Symbol : the name of the binary variable
 """
 function device_semicontinuousrange(psi_container::PSIContainer,
-                                    range_data::Dict{String,DeviceRange},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     binvar_name::Symbol)
@@ -135,7 +135,7 @@ end
 
 @doc raw"""
     reserve_device_semicontinuousrange(psi_container::PSIContainer,
-                                    range_data::Dict{String,DeviceRange},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     binvar_name::Symbol)
@@ -165,14 +165,14 @@ where limits in range_data.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* range_data::Dict{String,DeviceRange} : contains names and vector of min/max
+* range_data::Dict{String, DeviceRange} : contains names and vector of min/max
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the continuous variable
 * binvar_name::Symbol : the name of the binary variable
 """
 #This function looks suspicious and repetittive. Needs verification
 function reserve_device_semicontinuousrange(psi_container::PSIContainer,
-                                            range_data::Dict{String,DeviceRange},
+                                            range_data::Dict{String, DeviceRange},
                                             cons_name::Symbol,
                                             var_name::Symbol,
                                             binvar_name::Symbol)

--- a/src/devices_models/devices/common/range_constraint.jl
+++ b/src/devices_models/devices/common/range_constraint.jl
@@ -41,23 +41,21 @@ function device_range(psi_container::PSIContainer,
     con_ub = add_cons_container!(psi_container, ub_name, names, time_steps)
     con_lb = add_cons_container!(psi_container, lb_name, names, time_steps)
 
-    for data in range_data
-        for t in time_steps
-            expression_ub = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
-            for val in data.additional_terms_ub
-                JuMP.add_to_expression!(expression_ub, 
-                                        get_variable(psi_container, val)[data.name, t])
-            end
-            expression_lb = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
-            for val in data.additional_terms_lb
-                JuMP.add_to_expression!(expression_lb, 
-                                        get_variable(psi_container, val)[data.name, t], -1.0)
-            end
-            con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
-                                                    expression_ub <= data.limits.max)
-            con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
-                                                    expression_lb >= data.limits.min)
+    for data in range_data, t in time_steps
+        expression_ub = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+        for val in data.additional_terms_ub
+            JuMP.add_to_expression!(expression_ub, 
+                                    get_variable(psi_container, val)[data.name, t])
         end
+        expression_lb = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+        for val in data.additional_terms_lb
+            JuMP.add_to_expression!(expression_lb, 
+                                    get_variable(psi_container, val)[data.name, t], -1.0)
+        end
+        con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
+                                                expression_ub <= data.limits.max)
+        con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
+                                                expression_lb >= data.limits.min)
     end
 
     return
@@ -116,26 +114,24 @@ function device_semicontinuousrange(psi_container::PSIContainer,
     con_ub = add_cons_container!(psi_container, ub_name, names, time_steps)
     con_lb = add_cons_container!(psi_container, lb_name, names, time_steps)
 
-    for data in range_data
-        for t in time_steps
-            if JuMP.has_lower_bound(varcts[data.name, t])
-                JuMP.set_lower_bound(varcts[data.name, t], 0.0)
-            end
-            expression_ub = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
-            for val in data.additional_terms_ub
-                JuMP.add_to_expression!(expression_ub,
-                                        get_variable(psi_container, val)[data.name, t])
-            end
-            expression_lb = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
-            for val in data.additional_terms_lb
-                JuMP.add_to_expression!(expression_lb,
-                                        get_variable(psi_container, val)[data.name, t], -1.0)
-            end
-            con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
-                                    expression_ub <= data.limits.max * varbin[data.name, t])
-            con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
-                                    expression_lb >= data.limits.min * varbin[data.name, t])
+    for data in range_data, t in time_steps
+        if JuMP.has_lower_bound(varcts[data.name, t])
+            JuMP.set_lower_bound(varcts[data.name, t], 0.0)
         end
+        expression_ub = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
+        for val in data.additional_terms_ub
+            JuMP.add_to_expression!(expression_ub,
+                                    get_variable(psi_container, val)[data.name, t])
+        end
+        expression_lb = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
+        for val in data.additional_terms_lb
+            JuMP.add_to_expression!(expression_lb,
+                                    get_variable(psi_container, val)[data.name, t], -1.0)
+        end
+        con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                                expression_ub <= data.limits.max * varbin[data.name, t])
+        con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                                expression_lb >= data.limits.min * varbin[data.name, t])
     end
 
     return
@@ -197,26 +193,24 @@ function reserve_device_semicontinuousrange(psi_container::PSIContainer,
     con_ub = add_cons_container!(psi_container, ub_name, names, time_steps)
     con_lb = add_cons_container!(psi_container, lb_name, names, time_steps)
 
-    for data in range_data
-        for t in time_steps
-            if JuMP.has_lower_bound(varcts[data.name, t])
-                JuMP.set_lower_bound(varcts[data.name, t], 0.0)
-            end
-            expression_ub = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
-            for val in data.additional_terms_ub
-                JuMP.add_to_expression!(expression_ub,
-                                        get_variable(psi_container, val)[data.name, t])
-            end
-            expression_lb = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
-            for val in data.additional_terms_lb
-                JuMP.add_to_expression!(expression_lb,
-                                        get_variable(psi_container, val)[data.name, t], -1.0)
-            end
-            con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
-                                        expression_ub <= data.limits.max * (1 - varbin[data.name, t]))
-            con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
-                                        expression_lb >= data.limits.min * (1 - varbin[data.name, t]))
+    for data in range_data, t in time_steps
+        if JuMP.has_lower_bound(varcts[data.name, t])
+            JuMP.set_lower_bound(varcts[data.name, t], 0.0)
         end
+        expression_ub = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
+        for val in data.additional_terms_ub
+            JuMP.add_to_expression!(expression_ub,
+                                    get_variable(psi_container, val)[data.name, t])
+        end
+        expression_lb = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
+        for val in data.additional_terms_lb
+            JuMP.add_to_expression!(expression_lb,
+                                    get_variable(psi_container, val)[data.name, t], -1.0)
+        end
+        con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
+                                    expression_ub <= data.limits.max * (1 - varbin[data.name, t]))
+        con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                                    expression_lb >= data.limits.min * (1 - varbin[data.name, t]))
     end
     return
  end

--- a/src/devices_models/devices/common/timeseries_constraint.jl
+++ b/src/devices_models/devices/common/timeseries_constraint.jl
@@ -23,37 +23,36 @@ Constructs upper bound for given variable and time series data and a multiplier.
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_ub(psi_container::PSIContainer,
-                              ts_data::Dict{String, DeviceTimeSeries},
-                              range_data::Dict{String, DeviceRange},
+                              ts_data::Vector{DeviceTimeSeries},
                               cons_name::Symbol,
                               var_name::Symbol)
     time_steps = model_time_steps(psi_container)
-    names = collect(keys(ts_data))
+    names = (d.name for d in ts_data)
     variable = get_variable(psi_container, var_name)
     ub_name = _middle_rename(cons_name, "_", "ub")
     con_ub = add_cons_container!(psi_container, ub_name, names, time_steps)
-    add_lower_bound = !all(isempty.((r.additional_terms_lb for r in values(range_data))))
+    add_lower_bound = !all(isempty.((r.range.additional_terms_lb for r in ts_data)))
     if add_lower_bound
         lb_name = _middle_rename(cons_name, "_", "lb")
         con_lb = add_cons_container!(psi_container, lb_name, names, time_steps)
     end
 
-    for (name, data) in range_data
+    for data in ts_data
         for t in time_steps
-            expression_ub = JuMP.AffExpr(0.0, variable[name, t] => 1.0)
-            for val in data.additional_terms_ub
+            expression_ub = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+            for val in data.range.additional_terms_ub
                 JuMP.add_to_expression!(expression_ub, 
-                                        get_variable(psi_container, val)[name, t])
+                                        get_variable(psi_container, val)[data.name, t])
             end
-            con_ub[name, t] = JuMP.@constraint(psi_container.JuMPmodel,
-                                               expression_ub <= ts_data[name].multiplier *ts_data[name].timeseries[t])
+            con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                                    expression_ub <= data.multiplier * data.timeseries[t])
             if add_lower_bound
-                expression_lb = JuMP.AffExpr(0.0, variable[name, t] => 1.0)
-                for val in data.additional_terms_lb
+                expression_lb = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+                for val in data.range.additional_terms_lb
                     JuMP.add_to_expression!(expression_lb, 
-                                            get_variable(psi_container, val)[name, t], -1.0)
+                                            get_variable(psi_container, val)[data.name, t], -1.0)
                 end
-                con_lb[name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
                                                 expression_lb >= 0.0)
             end
         end
@@ -143,41 +142,40 @@ Constructs upper bound for given variable using a parameter. The constraint is
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_param_ub(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
+                                    ts_data::Vector{DeviceTimeSeries},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
     time_steps = model_time_steps(psi_container)
-    names = collect(keys(ts_data))
+    names = (d.name for d in ts_data)
     variable = get_variable(psi_container, var_name)
     ub_name = _middle_rename(cons_name, "_", "ub")
     con_ub = add_cons_container!(psi_container, ub_name, names, time_steps)
     param = _add_param_container!(psi_container, param_reference, names, time_steps)
-    add_lower_bound = !all(isempty.((r.additional_terms_lb for r in values(range_data))))
+    add_lower_bound = !all(isempty.((r.range.additional_terms_lb for r in ts_data)))
     if add_lower_bound
         lb_name = _middle_rename(cons_name, "_", "lb")
         con_lb = add_cons_container!(psi_container, lb_name, names, time_steps)
     end
 
-    for (name, data) in range_data
+    for data in ts_data
         for t in time_steps
-            expression_ub = JuMP.AffExpr(0.0, variable[name, t] => 1.0)
-            for val in data.additional_terms_ub
+            expression_ub = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+            for val in data.range.additional_terms_ub
                 JuMP.add_to_expression!(expression_ub, 
-                                        get_variable(psi_container, val)[name, t])
+                                        get_variable(psi_container, val)[data.name, t])
             end
-            param[name, t] = PJ.add_parameter(psi_container.JuMPmodel, 
-                                              ts_data[name].timeseries[t])
-            con_ub[name, t] = JuMP.@constraint(psi_container.JuMPmodel,
-                                               expression_ub <= ts_data[name].multiplier * param[name, t])
+            param[data.name, t] = PJ.add_parameter(psi_container.JuMPmodel, 
+                                                   data.timeseries[t])
+            con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                                               expression_ub <= data.multiplier * param[data.name, t])
             if add_lower_bound
-                expression_lb = JuMP.AffExpr(0.0, variable[name, t] => 1.0)
-                for val in data.additional_terms_lb
+                expression_lb = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+                for val in data.range.additional_terms_lb
                     JuMP.add_to_expression!(expression_lb, 
-                                            get_variable(psi_container, val)[name, t], -1.0)
+                                            get_variable(psi_container, val)[data.name, t], -1.0)
                 end
-                con_lb[name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                con_lb[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
                                                 expression_lb >= 0.0)
             end
         end

--- a/src/devices_models/devices/common/timeseries_constraint.jl
+++ b/src/devices_models/devices/common/timeseries_constraint.jl
@@ -361,7 +361,6 @@ function device_timeseries_ub_bigM(psi_container::PSIContainer,
     param =_add_param_container!(psi_container, param_reference, names, time_steps)
 
     for (name, data) in range_data
-        @assert name = names[ix]
         for t in time_steps
             expression_ub = JuMP.AffExpr(0.0, varcts[name, t] => 1.0)
             for val in data.additional_terms_ub

--- a/src/devices_models/devices/common/timeseries_constraint.jl
+++ b/src/devices_models/devices/common/timeseries_constraint.jl
@@ -17,7 +17,6 @@ Constructs upper bound for given variable and time series data and a multiplier.
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
 * ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the variable
 """
@@ -81,7 +80,6 @@ where (name, data) in range_data.
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
 * ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the variable
 """
@@ -132,7 +130,6 @@ Constructs upper bound for given variable using a parameter. The constraint is
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
 * ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * param_reference::UpdateRef : UpdateRef to access the parameter
 * var_name::Symbol : the name of the variable
@@ -201,7 +198,6 @@ Constructs lower bound for given variable using a parameter. The constraint is
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
 * ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * param_reference::UpdateRef : UpdateRef to access the parameter
 * var_name::Symbol : the name of the variable
@@ -258,7 +254,6 @@ where (name, data) in range_data.
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
 * ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol :  name of the variable
 * binvar_name::Symbol : name of binary variable
@@ -323,7 +318,6 @@ Constructs upper bound for variable and time series and a multiplier or confines
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
 * ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol :  name of the variable
 param_reference::UpdateRef : UpdateRef of access the parameters

--- a/src/devices_models/devices/common/timeseries_constraint.jl
+++ b/src/devices_models/devices/common/timeseries_constraint.jl
@@ -1,7 +1,7 @@
 @doc raw"""
     device_timeseries_ub(psi_container::PSIContainer,
-                     ts_data::Dict{String,DeviceTimeSeries},
-                     range_data::Dict{String,DeviceRange},
+                     ts_data::Dict{String, DeviceTimeSeries},
+                     range_data::Dict{String, DeviceRange},
                      cons_name::Symbol,
                      var_name::Symbol)
 
@@ -17,14 +17,14 @@ Constructs upper bound for given variable and time series data and a multiplier.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String,DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String,DeviceRange} : container of device range constraint modification data
+* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_ub(psi_container::PSIContainer,
-                              ts_data::Dict{String,DeviceTimeSeries},
-                              range_data::Dict{String,DeviceRange},
+                              ts_data::Dict{String, DeviceTimeSeries},
+                              range_data::Dict{String, DeviceRange},
                               cons_name::Symbol,
                               var_name::Symbol)
     time_steps = model_time_steps(psi_container)
@@ -64,8 +64,8 @@ end
 
 @doc raw"""
     device_timeseries_lb(psi_container::PSIContainer,
-                     ts_data::Dict{String,DeviceTimeSeries},
-                     range_data::Dict{String,DeviceRange},
+                     ts_data::Dict{String, DeviceTimeSeries},
+                     range_data::Dict{String, DeviceRange},
                      cons_name::Symbol,
                      var_name::Symbol)
 
@@ -83,14 +83,14 @@ where (name, data) in range_data.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String,DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String,DeviceRange} : container of device range constraint modification data
+* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_lb(psi_container::PSIContainer,
-                              ts_data::Dict{String,DeviceTimeSeries},
-                              range_data::Dict{String,DeviceRange},
+                              ts_data::Dict{String, DeviceTimeSeries},
+                              range_data::Dict{String, DeviceRange},
                               cons_name::Symbol,
                               var_name::Symbol)
     time_steps = model_time_steps(psi_container)
@@ -117,8 +117,8 @@ end
 #NOTE: there is a floating, unnamed lower bound constraint in this function. This may need to be changed.
 @doc raw"""
     device_timeseries_param_ub(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
@@ -136,15 +136,15 @@ Constructs upper bound for given variable using a parameter. The constraint is
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String,DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String,DeviceRange} : container of device range constraint modification data
+* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * param_reference::UpdateRef : UpdateRef to access the parameter
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_param_ub(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
@@ -188,8 +188,8 @@ end
 
 @doc raw"""
     device_timeseries_param_lb(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
@@ -207,15 +207,15 @@ Constructs lower bound for given variable using a parameter. The constraint is
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String,DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String,DeviceRange} : container of device range constraint modification data
+* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * param_reference::UpdateRef : UpdateRef to access the parameter
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_param_lb(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
@@ -246,8 +246,8 @@ end
 
 @doc raw"""
     device_timeseries_ub_bin(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     var_name::Symbol,
                                     binvar_name::Symbol)
 
@@ -266,15 +266,15 @@ where (name, data) in range_data.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String,DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String,DeviceRange} : container of device range constraint modification data
+* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol :  name of the variable
 * binvar_name::Symbol : name of binary variable
 """
 function device_timeseries_ub_bin(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     binvar_name::Symbol)
@@ -308,8 +308,8 @@ end
 
 @doc raw"""
     device_timeseries_ub_bigM(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     param_reference::UpdateRef,
@@ -333,8 +333,8 @@ Constructs upper bound for variable and time series and a multiplier or confines
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String,DeviceTimeSeries} : container of device time series data and scaling factors
-* range_data::Dict{String,DeviceRange} : container of device range constraint modification data
+* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol :  name of the variable
 param_reference::UpdateRef : UpdateRef of access the parameters
@@ -342,8 +342,8 @@ param_reference::UpdateRef : UpdateRef of access the parameters
 * M_value::Float64 : bigM
 """
 function device_timeseries_ub_bigM(psi_container::PSIContainer,
-                                    ts_data::Dict{String,DeviceTimeSeries},
-                                    range_data::Dict{String,DeviceRange},
+                                    ts_data::Dict{String, DeviceTimeSeries},
+                                    range_data::Dict{String, DeviceRange},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     param_reference::UpdateRef,

--- a/src/devices_models/devices/common/timeseries_constraint.jl
+++ b/src/devices_models/devices/common/timeseries_constraint.jl
@@ -1,7 +1,6 @@
 @doc raw"""
     device_timeseries_ub(psi_container::PSIContainer,
-                     ts_data::Dict{String, DeviceTimeSeries},
-                     range_data::Dict{String, DeviceRange},
+                     ts_data::Vector{DeviceTimeSeries},
                      cons_name::Symbol,
                      var_name::Symbol)
 
@@ -17,7 +16,7 @@ Constructs upper bound for given variable and time series data and a multiplier.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
 * range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the variable
@@ -63,8 +62,7 @@ end
 
 @doc raw"""
     device_timeseries_lb(psi_container::PSIContainer,
-                     ts_data::Dict{String, DeviceTimeSeries},
-                     range_data::Dict{String, DeviceRange},
+                     ts_data::Vector{DeviceTimeSeries},
                      cons_name::Symbol,
                      var_name::Symbol)
 
@@ -82,31 +80,30 @@ where (name, data) in range_data.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
 * range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_lb(psi_container::PSIContainer,
-                              ts_data::Dict{String, DeviceTimeSeries},
-                              range_data::Dict{String, DeviceRange},
+                              ts_data::Vector{DeviceTimeSeries},
                               cons_name::Symbol,
                               var_name::Symbol)
     time_steps = model_time_steps(psi_container)
     variable = get_variable(psi_container, var_name)
     lb_name = _middle_rename(cons_name, "_", "lb")
-    names = collect(keys(ts_data))
+    names = (d.name for d in ts_data)
     constraint = add_cons_container!(psi_container, lb_name, names, time_steps)
 
-    for (name, data) in range_data
+    for data in ts_data
         for t in time_steps
-            expression_lb = JuMP.AffExpr(0.0, variable[name, t] => 1.0)
-            for val in data.additional_terms_lb
+            expression_lb = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+            for val in data.range.additional_terms_lb
                 JuMP.add_to_expression!(expression_lb, 
-                                        get_variable(psi_container, val)[name, t], -1.0)
+                                        get_variable(psi_container, val)[data.name, t], -1.0)
             end
-            constraint[name, t] = JuMP.@constraint(psi_container.JuMPmodel,
-                                                   expression_lb >= ts_data[name].multiplier * ts_data[name].timeseries[t])
+            constraint[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                                            expression_lb >= data.multiplier * data.timeseries[t])
         end
     end
 
@@ -116,8 +113,7 @@ end
 #NOTE: there is a floating, unnamed lower bound constraint in this function. This may need to be changed.
 @doc raw"""
     device_timeseries_param_ub(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
+                                    ts_data::Vector{DeviceTimeSeries},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
@@ -135,7 +131,7 @@ Constructs upper bound for given variable using a parameter. The constraint is
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
 * range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * param_reference::UpdateRef : UpdateRef to access the parameter
@@ -186,8 +182,7 @@ end
 
 @doc raw"""
     device_timeseries_param_lb(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
+                                    ts_data::Vector{DeviceTimeSeries},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
@@ -205,36 +200,35 @@ Constructs lower bound for given variable using a parameter. The constraint is
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
 * range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * param_reference::UpdateRef : UpdateRef to access the parameter
 * var_name::Symbol : the name of the variable
 """
 function device_timeseries_param_lb(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
+                                    ts_data::Vector{DeviceTimeSeries},
                                     cons_name::Symbol,
                                     param_reference::UpdateRef,
                                     var_name::Symbol)
     time_steps = model_time_steps(psi_container)
     variable = get_variable(psi_container, var_name)
     lb_name = _middle_rename(cons_name, "_", "lb")
-    names = collect(keys(ts_datta))
+    names = (d.name for d in ts_data)
     constraint =add_cons_container!(psi_container, lb_name, names, time_steps)
     param =_add_param_container!(psi_container, param_reference, names, time_steps)
 
-    for (name, data) in range_data
+    for data in ts_data
         for t in time_steps
-            expression_lb = JuMP.AffExpr(0.0, variable[name, t] => 1.0)
-            for val in data.additional_terms_lb
+            expression_lb = JuMP.AffExpr(0.0, variable[data.name, t] => 1.0)
+            for val in data.range.additional_terms_lb
                 JuMP.add_to_expression!(expression_lb, 
-                                        get_variable(psi_container, val)[name, t], -1.0)
+                                        get_variable(psi_container, val)[data.name, t], -1.0)
             end
-            param[name, t] = PJ.add_parameter(psi_container.JuMPmodel,
-                                              ts_data[name].timeseries[t])
-            constraint[name, t] = JuMP.@constraint(psi_container.JuMPmodel,
-                                                   expression_lb >= ts_data[name].multiplier * param[name, t])
+            param[data.name, t] = PJ.add_parameter(psi_container.JuMPmodel,
+                                                   data.timeseries[t])
+            constraint[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel,
+                                            expression_lb >= data.multiplier * param[name, t])
         end
     end
 
@@ -244,8 +238,7 @@ end
 
 @doc raw"""
     device_timeseries_ub_bin(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
+                                    ts_data::Vector{DeviceTimeSeries},
                                     var_name::Symbol,
                                     binvar_name::Symbol)
 
@@ -264,15 +257,14 @@ where (name, data) in range_data.
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
 * range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol :  name of the variable
 * binvar_name::Symbol : name of binary variable
 """
 function device_timeseries_ub_bin(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
+                                    ts_data::Vector{DeviceTimeSeries},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     binvar_name::Symbol)
@@ -283,20 +275,20 @@ function device_timeseries_ub_bin(psi_container::PSIContainer,
     varcts = get_variable(psi_container, var_name)
     varbin = get_variable(psi_container, binvar_name)
 
-    names = collect(keys(ts_data))
+    names = (d.name for d in ts_data)
     con_ub =add_cons_container!(psi_container, ub_name, names, time_steps)
 
-    for (name, data) in range_data
+    for data in ts_data
         for t in time_steps
-            forecast = ts_data[name].timeseries[t]
-            multiplier = ts_data[name].multiplier
-            expression_ub = JuMP.AffExpr(0.0, varcts[name, t] => 1.0)
-            for val in data.additional_terms_ub
+            forecast = data.timeseries[t]
+            multiplier = data.multiplier
+            expression_ub = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
+            for val in data.range.additional_terms_ub
                 JuMP.add_to_expression!(expression_ub, 
-                                        get_variable(psi_container, val)[name, t])
+                                        get_variable(psi_container, val)[data.name, t])
             end
-            con_ub[name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
-                                               expression_ub <= varbin[name, t] * multiplier * forecast)
+            con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
+                                        expression_ub <= varbin[data.name, t] * multiplier * forecast)
         end
     end
 
@@ -306,8 +298,7 @@ end
 
 @doc raw"""
     device_timeseries_ub_bigM(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
+                                    ts_data::Vector{DeviceTimeSeries},
                                     cons_name::Symbol,
                                     var_name::Symbol,
                                     param_reference::UpdateRef,
@@ -331,7 +322,7 @@ Constructs upper bound for variable and time series and a multiplier or confines
 
 # Arguments
 * psi_container::PSIContainer : the psi_container model built in PowerSimulations
-* ts_data::Dict{String, DeviceTimeSeries} : container of device time series data and scaling factors
+* ts_data::Vector{DeviceTimeSeries} : container of device time series data and scaling factors
 * range_data::Dict{String, DeviceRange} : container of device range constraint modification data
 * cons_name::Symbol : name of the constraint
 * var_name::Symbol :  name of the variable
@@ -340,9 +331,7 @@ param_reference::UpdateRef : UpdateRef of access the parameters
 * M_value::Float64 : bigM
 """
 function device_timeseries_ub_bigM(psi_container::PSIContainer,
-                                    ts_data::Dict{String, DeviceTimeSeries},
-                                    range_data::Dict{String, DeviceRange},
-                                    cons_name::Symbol,
+                                    ts_data::Vector{DeviceTimeSeries},                                    cons_name::Symbol,
                                     var_name::Symbol,
                                     param_reference::UpdateRef,
                                     binvar_name::Symbol,
@@ -353,23 +342,24 @@ function device_timeseries_ub_bigM(psi_container::PSIContainer,
 
     varcts = get_variable(psi_container, var_name)
     varbin = get_variable(psi_container, binvar_name)
-    names = collect(keys(ts_data))
+    names = (d.name for d in ts_data)
     con_ub = add_cons_container!(psi_container, ub_name, names, time_steps)
     con_status =add_cons_container!(psi_container, key_status, names, time_steps)
     param =_add_param_container!(psi_container, param_reference, names, time_steps)
 
-    for (name, data) in range_data
+    for data in ts_data
         for t in time_steps
-            expression_ub = JuMP.AffExpr(0.0, varcts[name, t] => 1.0)
-            for val in data.additional_terms_ub
+            expression_ub = JuMP.AffExpr(0.0, varcts[data.name, t] => 1.0)
+            for val in data.range.additional_terms_ub
                 JuMP.add_to_expression!(expression_ub, 
-                                        get_variable(psi_container, val)[name, t])
+                                        get_variable(psi_container, val)[data.name, t])
             end
-            param[name, t] = PJ.add_parameter(psi_container.JuMPmodel, ts_data[name].timeseries[t])
-            con_ub[name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
-                expression_ub - param[name, t] * ts_data[name].multiplier <= (1 - varbin[name, t]) * M_value)
-            con_status[name, t] =  JuMP.@constraint(psi_container.JuMPmodel, 
-                                                    expression_ub <= varbin[name, t] * M_value)
+            param[data.name, t] = PJ.add_parameter(psi_container.JuMPmodel, 
+                                                   data.timeseries[t])
+            con_ub[data.name, t] = JuMP.@constraint(psi_container.JuMPmodel, 
+                expression_ub - param[data.name, t] * data.multiplier <= (1 - varbin[data.name, t]) * M_value)
+            con_status[data.name, t] =  JuMP.@constraint(psi_container.JuMPmodel, 
+                                            expression_ub <= varbin[data.name, t] * M_value)
         end
     end
 

--- a/src/devices_models/devices/electric_loads.jl
+++ b/src/devices_models/devices/electric_loads.jl
@@ -67,15 +67,19 @@ end
 
 ######################## output constraints without Time Series ############################
 function _get_time_series(psi_container::PSIContainer,
-                          devices::IS.FlattenIteratorWrapper{<:PSY.ElectricLoad})
+                          devices::IS.FlattenIteratorWrapper{<:PSY.ElectricLoad},
+                          model::DeviceModel = DeviceModel(PSY.PowerLoad, StaticPowerLoad),
+                          get_constraint_values::Function = x -> (min = 0.0, max = 0.0))
     initial_time = model_initial_time(psi_container)
     use_forecast_data = model_uses_forecasts(psi_container)
     time_steps = model_time_steps(psi_container)
     device_total = length(devices)
-    ts_data_active = Vector{Tuple{String, Int64, Float64, Vector{Float64}}}(undef, device_total)
-    ts_data_reactive = Vector{Tuple{String, Int64, Float64, Vector{Float64}}}(undef, device_total)
 
-    for (ix, device) in enumerate(devices)
+    constraint_data = Dict{String, DeviceRange}()
+    ts_data_active = Dict{String, DeviceTimeSeries}()
+    ts_data_reactive = Dict{String, DeviceTimeSeries}()
+
+    for device in devices
         bus_number = PSY.get_number(PSY.get_bus(device))
         name = PSY.get_name(device)
         active_power = use_forecast_data ? PSY.get_maxactivepower(device) : PSY.get_activepower(device)
@@ -90,11 +94,15 @@ function _get_time_series(psi_container::PSIContainer,
         else
             ts_vector = ones(time_steps[end])
         end
-        ts_data_active[ix] = (name, bus_number, active_power, ts_vector)
-        ts_data_reactive[ix] = (name, bus_number, reactive_power, ts_vector)
+        ts_data_active[name] = DeviceTimeSeries(bus_number, active_power, ts_vector)
+        ts_data_reactive[name] = DeviceTimeSeries(bus_number, reactive_power, ts_vector)
+        constraint_data[name] = DeviceRange(get_constraint_values(device), 
+                                            Vector{Symbol}(), 
+                                            Vector{Symbol}())
+        _device_services(constraint_data[name], device, model)
     end
 
-    return ts_data_active, ts_data_reactive
+    return ts_data_active, ts_data_reactive, constraint_data
 
 end
 
@@ -106,12 +114,9 @@ function activepower_constraints!(psi_container::PSIContainer,
     parameters = model_has_parameters(psi_container)
     use_forecast_data = model_uses_forecasts(psi_container)
 
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        ub_value = PSY.get_activepower(d)
-        constraint_data.values[ix] = (min=0.0, max=ub_value)
-        constraint_data.names[ix] = PSY.get_name(d)
-    end
+    ts_data_active, _, constraint_data = _get_time_series(psi_container, devices, model,
+                                                          x -> (min=0.0, max=PSY.get_activepower(x)))
+
     if !parameters && !use_forecast_data
         device_range(psi_container,
                      constraint_data,
@@ -120,7 +125,6 @@ function activepower_constraints!(psi_container::PSIContainer,
         return
     end
 
-    ts_data_active, _ = _get_time_series(psi_container, devices)
     if parameters
         device_timeseries_param_ub(psi_container,
                                    ts_data_active,
@@ -146,12 +150,9 @@ function activepower_constraints!(psi_container::PSIContainer,
     parameters = model_has_parameters(psi_container)
     use_forecast_data = model_uses_forecasts(psi_container)
 
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        ub_value = PSY.get_activepower(d)
-        constraint_data.values[ix] = (min=0.0, max=ub_value)
-        constraint_data.names[ix] = PSY.get_name(d)
-    end
+    ts_data_active, _, constraint_data = _get_time_series(psi_container, devices, model,
+                                                          x -> (min=0.0, max=PSY.get_activepower(x)))
+
     if !parameters && !use_forecast_data
         device_range(psi_container,
                     constraint_data,
@@ -160,7 +161,6 @@ function activepower_constraints!(psi_container::PSIContainer,
         return
     end
 
-    ts_data_active, _ = _get_time_series(psi_container, devices)
     if parameters
         device_timeseries_ub_bigM(psi_container,
                                  ts_data_active,
@@ -203,17 +203,17 @@ function nodal_expression!(psi_container::PSIContainer,
     end
 
     for t in model_time_steps(psi_container)
-        for device_value in ts_data_active
+        for (name, device_value) in ts_data_active
             _add_to_expression!(psi_container.expressions[:nodal_balance_active],
-                            device_value[2],
+                            device_value.bus_number,
                             t,
-                            -device_value[3]*device_value[4][t])
+                            -device_value.multiplier * device_value.timeseries[t])
         end
-        for device_value in ts_data_reactive
+        for (name, device_value) in ts_data_reactive
             _add_to_expression!(psi_container.expressions[:nodal_balance_reactive],
-                            device_value[2],
+                            device_value.bus_number,
                             t,
-                            -device_value[3]*device_value[4][t])
+                            -device_value.multiplier * device_value.timeseries[t])
         end
     end
 
@@ -237,11 +237,11 @@ function nodal_expression!(psi_container::PSIContainer,
         return
     end
 
-    for t in model_time_steps(psi_container), device_value in ts_data_active
+    for t in model_time_steps(psi_container), (name, device_value) in ts_data_active
         _add_to_expression!(psi_container.expressions[:nodal_balance_active],
-                            device_value[2],
+                            device_value.bus_number,
                             t,
-                            -device_value[3]*device_value[4][t])
+                            -device_value.multiplier * device_value.timeseries[t])
     end
 
     return

--- a/src/devices_models/devices/electric_loads.jl
+++ b/src/devices_models/devices/electric_loads.jl
@@ -99,7 +99,7 @@ function _get_time_series(psi_container::PSIContainer,
         constraint_data[name] = DeviceRange(get_constraint_values(device), 
                                             Vector{Symbol}(), 
                                             Vector{Symbol}())
-        _device_services(constraint_data[name], device, model)
+        _device_services!(constraint_data[name], device, model)
     end
 
     return ts_data_active, ts_data_reactive, constraint_data

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -89,7 +89,7 @@ function reactivepower_constraints!(psi_container::PSIContainer,
     for (ix, d) in enumerate(devices)
         constraint_data.values[ix] = PSY.get_reactivepowerlimits(PSY.get_tech(d))
         constraint_data.names[ix] = PSY.get_name(d)
-        #_device_services(constraint_data, ix, d, model)
+        #_device_services!(constraint_data, ix, d, model)
         # Uncomment when we implement reactive power services
     end
 
@@ -134,7 +134,7 @@ function _get_time_series(psi_container::PSIContainer,
         constraint_data[name] = DeviceRange(get_constraint_values(device), 
                                             Vector{Symbol}(), 
                                             Vector{Symbol}())
-        _device_services(constraint_data[name], device, model)
+        _device_services!(constraint_data[name], device, model)
     end
     return active_timeseries, reactive_timeseries, constraint_data
 end

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -85,12 +85,14 @@ function reactivepower_constraints!(psi_container::PSIContainer,
                                     model::DeviceModel{H, AbstractHydroDispatchFormulation},
                                     system_formulation::Type{<:PM.AbstractPowerModel},
                                     feed_forward::Union{Nothing, AbstractAffectFeedForward}) where H<:PSY.HydroGen
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data.values[ix] = PSY.get_reactivepowerlimits(PSY.get_tech(d))
-        constraint_data.names[ix] = PSY.get_name(d)
-        #_device_services!(constraint_data, ix, d, model)
+    constraint_data = Vector(DeviceRange)()
+    for d in devices
+        limits =  PSY.get_reactivepowerlimits(PSY.get_tech(d))
+        name =  PSY.get_name(d)
+        range_data = DeviceRange(name, limits)
+        #_device_services!(range_data, d, model)
         # Uncomment when we implement reactive power services
+        push!(constraint_data, range_data)
     end
 
     device_range(psi_container,

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -76,8 +76,8 @@ end
 ######################## output constraints without Time Series ############################
 function _get_time_series(psi_container::PSIContainer,
                           devices::IS.FlattenIteratorWrapper{<:PSY.RenewableGen},
-                          model::Union{Nothing,DeviceModel} = nothing,
-                          get_constraint_values::Function = x -> nothing)
+                          model::Union{Nothing,DeviceModel} = DeviceModel(PSY.HydroFix, PSI.HydroFixed),
+                          get_constraint_values::Function = x -> (min = 0.0, max = 0.0))
     initial_time = model_initial_time(psi_container)
     use_forecast_data = model_uses_forecasts(psi_container)
     parameters = model_has_parameters(psi_container)
@@ -168,17 +168,17 @@ function nodal_expression!(psi_container::PSIContainer,
         return
     end
     for t in model_time_steps(psi_container)
-        for device_value in ts_data_active
+        for (name, device_value) in ts_data_active
             _add_to_expression!(psi_container.expressions[:nodal_balance_active],
-                            device_value[2],
+                            device_value.bus_number,
                             t,
-                            device_value[3]*device_value[4][t])
+                            device_value.multiplier * device_value.timeseries[t])
         end
-        for device_value in ts_data_reactive
+        for (name, device_value) in ts_data_reactive
             _add_to_expression!(psi_container.expressions[:nodal_balance_reactive],
-                            device_value[2],
+                            device_value.bus_number,
                             t,
-                            device_value[3]*device_value[4][t])
+                            device_value.multiplier * device_value.timeseries[t])
         end
     end
     return
@@ -197,11 +197,11 @@ function nodal_expression!(psi_container::PSIContainer,
         return
     end
     for t in model_time_steps(psi_container)
-        for device_value in ts_data_active
+        for (name, device_value) in ts_data_active
             _add_to_expression!(psi_container.expressions[:nodal_balance_active],
-                            device_value[2],
+                            device_value.bus_number,
                             t,
-                            device_value[3]*device_value[4][t])
+                            device_value.multiplier * device_value.timeseries[t])
         end
     end
     return

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -33,7 +33,7 @@ function reactivepower_constraints!(psi_container::PSIContainer,
                                     model::DeviceModel{R, RenewableFullDispatch},
                                     system_formulation::Type{<:PM.AbstractPowerModel},
                                     feed_forward::Union{Nothing, AbstractAffectFeedForward}) where R<:PSY.RenewableGen
-    constraint_data = Dict{String,DeviceRange}()
+    constraint_data = Dict{String, DeviceRange}()
     for (ix, d) in enumerate(devices)
         tech = PSY.get_tech(d)
         name = PSY.get_name(d)

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -87,7 +87,7 @@ function _get_time_series(psi_container::PSIContainer,
     active_timeseries = Dict{String, DeviceTimeSeries}()
     reactive_timeseries = Dict{String, DeviceTimeSeries}()
 
-    for (ix, device) in enumerate(devices)
+    for device in devices
         bus_number = PSY.get_number(PSY.get_bus(device))
         name = PSY.get_name(device)
         tech = PSY.get_tech(device)

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -106,8 +106,8 @@ function _get_time_series(psi_container::PSIContainer,
         active_timeseries[name] = DeviceTimeSeries(bus_number, active_power, ts_vector)
         reactive_timeseries[name] = DeviceTimeSeries(bus_number, active_power * pf, ts_vector)
         constraint_data[name] = DeviceRange(get_constraint_values(device), 
-                                      Vector{Symbol}(), 
-                                      Vector{Symbol}())
+                                            Vector{Symbol}(), 
+                                            Vector{Symbol}())
         _device_services(constraint_data[name], device, model)
     end
     return active_timeseries, reactive_timeseries, constraint_data

--- a/src/devices_models/devices/storage.jl
+++ b/src/devices_models/devices/storage.jl
@@ -61,16 +61,14 @@ function active_power_constraints!(psi_container::PSIContainer,
                                    ::Type{S},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                      S<:PM.AbstractPowerModel}
-    constraint_data_in = Dict{String, DeviceRange}()
-    constraint_data_out = Dict{String, DeviceRange}()
+    constraint_data_in = Vector{DeviceRange}()
+    constraint_data_out = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
         in_lims = PSY.get_inputactivepowerlimits(d)
         out_lims = PSY.get_outputactivepowerlimits(d)
-        constraint_data_in[name] = DeviceRange(in_lims, Vector{Symbol}(), Vector{Symbol}())
-        constraint_data_out[name] = DeviceRange(out_lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services!(constraint_data_in, d, model)
-        #_device_services!(constraint_data_out, d, model)
+        push!(constraint_data_in, DeviceRange(name, in_lims)) #_device_services!(DeviceRange(name, in_lims), d, model)
+        push!(constraint_data_out, DeviceRange(name, out_lims)) #_device_services!(DeviceRange(name, out_lims), d, model)
     end
 
     device_range(psi_container,
@@ -91,16 +89,15 @@ function active_power_constraints!(psi_container::PSIContainer,
                                    ::Type{S},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                      S<:PM.AbstractPowerModel}
-    constraint_data_in = Dict{String, DeviceRange}()
-    constraint_data_out = Dict{String, DeviceRange}()
+    constraint_data_in = Vector{DeviceRange}()
+    constraint_data_out = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
         in_lims = PSY.get_inputactivepowerlimits(d)
         out_lims =  PSY.get_outputactivepowerlimits(d)
-        constraint_data_in[name] = DeviceRange(in_lims, Vector{Symbol}(), Vector{Symbol}())
-        constraint_data_out[name] = DeviceRange(out_lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services!(constraint_data_in, d, model)
-        #_device_services!(constraint_data_out, d, model)
+        push!(constraint_data_in, DeviceRange(name, in_lims)) #_device_services!(DeviceRange(name, in_lims), d, model)
+        push!(constraint_data_out, DeviceRange(name, out_lims)) #_device_services!(DeviceRange(name, out_lims), d, model)
+
     end
     reserve_device_semicontinuousrange(psi_container,
                                        constraint_data_in,
@@ -127,12 +124,11 @@ function reactive_power_constraints!(psi_container::PSIContainer,
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                      D<:AbstractStorageFormulation,
                                                      S<:PM.AbstractPowerModel}
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
         lims = PSY.get_reactivepowerlimits(d)
-        constraint_data[name] = DeviceRange(lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services!(constraint_data, d, model)
+        push!(constraint_data, DeviceRange(name, lims)) #_device_services!(DeviceRange(name, lims), d, model)
         # Uncomment when we implement reactive power services
     end
 
@@ -161,12 +157,11 @@ function energy_capacity_constraints!(psi_container::PSIContainer,
                                     feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                                         D<:AbstractStorageFormulation,
                                                                         S<:PM.AbstractPowerModel}
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
         lims= PSY.get_capacity(d)
-        constraint_data[name] = DeviceRange(lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services!(constraint_data, d, model)
+        push!(constraint_data, DeviceRange(name, lims)) #_device_services!(DeviceRange(name, lims), d, model)
         # Uncomment when we implement reactive power services
     end
 

--- a/src/devices_models/devices/storage.jl
+++ b/src/devices_models/devices/storage.jl
@@ -69,8 +69,8 @@ function active_power_constraints!(psi_container::PSIContainer,
         out_lims = PSY.get_outputactivepowerlimits(d)
         constraint_data_in[name] = DeviceRange(in_lims, Vector{Symbol}(), Vector{Symbol}())
         constraint_data_out[name] = DeviceRange(out_lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services(constraint_data_in, d, model)
-        #_device_services(constraint_data_out, d, model)
+        #_device_services!(constraint_data_in, d, model)
+        #_device_services!(constraint_data_out, d, model)
     end
 
     device_range(psi_container,
@@ -99,8 +99,8 @@ function active_power_constraints!(psi_container::PSIContainer,
         out_lims =  PSY.get_outputactivepowerlimits(d)
         constraint_data_in[name] = DeviceRange(in_lims, Vector{Symbol}(), Vector{Symbol}())
         constraint_data_out[name] = DeviceRange(out_lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services(constraint_data_in, d, model)
-        #_device_services(constraint_data_out, d, model)
+        #_device_services!(constraint_data_in, d, model)
+        #_device_services!(constraint_data_out, d, model)
     end
     reserve_device_semicontinuousrange(psi_container,
                                        constraint_data_in,
@@ -132,7 +132,7 @@ function reactive_power_constraints!(psi_container::PSIContainer,
         name = PSY.get_name(d)
         lims = PSY.get_reactivepowerlimits(d)
         constraint_data[name] = DeviceRange(lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services(constraint_data, d, model)
+        #_device_services!(constraint_data, d, model)
         # Uncomment when we implement reactive power services
     end
 
@@ -166,7 +166,7 @@ function energy_capacity_constraints!(psi_container::PSIContainer,
         name = PSY.get_name(d)
         lims= PSY.get_capacity(d)
         constraint_data[name] = DeviceRange(lims, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services(constraint_data, d, model)
+        #_device_services!(constraint_data, d, model)
         # Uncomment when we implement reactive power services
     end
 

--- a/src/devices_models/devices/storage.jl
+++ b/src/devices_models/devices/storage.jl
@@ -127,9 +127,11 @@ function reactive_power_constraints!(psi_container::PSIContainer,
     constraint_data = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
-        lims = PSY.get_reactivepowerlimits(d)
-        push!(constraint_data, DeviceRange(name, lims)) #_device_services!(DeviceRange(name, lims), d, model)
+        limits = PSY.get_reactivepowerlimits(d)
+        range_data = DeviceRange(name, limits)
+        #_device_services!(range_data, d, model)
         # Uncomment when we implement reactive power services
+        push!(constraint_data, range_data)
     end
 
     device_range(psi_container,
@@ -160,9 +162,11 @@ function energy_capacity_constraints!(psi_container::PSIContainer,
     constraint_data = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
-        lims= PSY.get_capacity(d)
-        push!(constraint_data, DeviceRange(name, lims)) #_device_services!(DeviceRange(name, lims), d, model)
+        limits= PSY.get_capacity(d)
+        range_data = DeviceRange(name, limits)
+        #_device_services!(range_data, d, model)
         # Uncomment when we implement reactive power services
+        push!(constraint_data, range_data)
     end
 
     device_range(psi_container,

--- a/src/devices_models/devices/storage.jl
+++ b/src/devices_models/devices/storage.jl
@@ -61,13 +61,16 @@ function active_power_constraints!(psi_container::PSIContainer,
                                    ::Type{S},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                      S<:PM.AbstractPowerModel}
-    constraint_data_in = DeviceRange(length(devices))
-    constraint_data_out = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data_in.values[ix] = PSY.get_inputactivepowerlimits(d)
-        constraint_data_out.values[ix] = PSY.get_outputactivepowerlimits(d)
-        constraint_data_in.names[ix] = constraint_data_out.names[ix] = PSY.get_name(d)
-        #_device_services(constraint_data, ix, d, model)
+    constraint_data_in = Dict{String, DeviceRange}()
+    constraint_data_out = Dict{String, DeviceRange}()
+    for d in devices
+        name = PSY.get_name(d)
+        in_lims = PSY.get_inputactivepowerlimits(d)
+        out_lims = PSY.get_outputactivepowerlimits(d)
+        constraint_data_in[name] = DeviceRange(in_lims, Vector{Symbol}(), Vector{Symbol}())
+        constraint_data_out[name] = DeviceRange(out_lims, Vector{Symbol}(), Vector{Symbol}())
+        #_device_services(constraint_data_in, d, model)
+        #_device_services(constraint_data_out, d, model)
     end
 
     device_range(psi_container,
@@ -88,13 +91,16 @@ function active_power_constraints!(psi_container::PSIContainer,
                                    ::Type{S},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                      S<:PM.AbstractPowerModel}
-    constraint_data_in = DeviceRange(length(devices))
-    constraint_data_out = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data_in.values[ix] = PSY.get_inputactivepowerlimits(d)
-        constraint_data_out.values[ix] = PSY.get_outputactivepowerlimits(d)
-        constraint_data_in.names[ix] = constraint_data_out.names[ix] = PSY.get_name(d)
-        #_device_services(constraint_data, ix, d, model)
+    constraint_data_in = Dict{String, DeviceRange}()
+    constraint_data_out = Dict{String, DeviceRange}()
+    for d in devices
+        name = PSY.get_name(d)
+        in_lims = PSY.get_inputactivepowerlimits(d)
+        out_lims =  PSY.get_outputactivepowerlimits(d)
+        constraint_data_in[name] = DeviceRange(in_lims, Vector{Symbol}(), Vector{Symbol}())
+        constraint_data_out[name] = DeviceRange(out_lims, Vector{Symbol}(), Vector{Symbol}())
+        #_device_services(constraint_data_in, d, model)
+        #_device_services(constraint_data_out, d, model)
     end
     reserve_device_semicontinuousrange(psi_container,
                                        constraint_data_in,
@@ -121,16 +127,17 @@ function reactive_power_constraints!(psi_container::PSIContainer,
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                      D<:AbstractStorageFormulation,
                                                      S<:PM.AbstractPowerModel}
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data.values[ix] = PSY.get_reactivepowerlimits(d)
-        constraint_data.names[ix] = PSY.get_name(d)
-        #_device_services(constraint_data, ix, d, model)
+    constraint_data = Dict{String, DeviceRange}()
+    for d in devices
+        name = PSY.get_name(d)
+        lims = PSY.get_reactivepowerlimits(d)
+        constraint_data[name] = DeviceRange(lims, Vector{Symbol}(), Vector{Symbol}())
+        #_device_services(constraint_data, d, model)
         # Uncomment when we implement reactive power services
     end
 
     device_range(psi_container,
-                constraint_data,
+                 constraint_data,
                  Symbol("reactiverange_$(St)"),
                  Symbol("Q_$(St)"))
     return
@@ -154,11 +161,12 @@ function energy_capacity_constraints!(psi_container::PSIContainer,
                                     feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {St<:PSY.Storage,
                                                                         D<:AbstractStorageFormulation,
                                                                         S<:PM.AbstractPowerModel}
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data.values[ix] = PSY.get_capacity(d)
-        constraint_data.names[ix] = PSY.get_name(d)
-        #_device_services(constraint_data, ix, d, model)
+    constraint_data = Dict{String, DeviceRange}()
+    for d in devices
+        name = PSY.get_name(d)
+        lims= PSY.get_capacity(d)
+        constraint_data[name] = DeviceRange(lims, Vector{Symbol}(), Vector{Symbol}())
+        #_device_services(constraint_data, d, model)
         # Uncomment when we implement reactive power services
     end
 

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -80,7 +80,7 @@ function activepower_constraints!(psi_container::PSIContainer,
         name = PSY.get_name(d)
         values = PSY.get_activepowerlimits(PSY.get_tech(d))
         constraint_data[name] = DeviceRange(values, Vector{Symbol}(), Vector{Symbol}())
-        _device_services(constraint_data[name], d, model)
+        _device_services!(constraint_data[name], d, model)
     end
     device_range(psi_container,
                  constraint_data,
@@ -102,7 +102,7 @@ function activepower_constraints!(psi_container::PSIContainer,
         limits = PSY.get_activepowerlimits(PSY.get_tech(d))
         name = PSY.get_name(d)
         constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        _device_services(constraint_data[name], d, model)
+        _device_services!(constraint_data[name], d, model)
     end
     device_semicontinuousrange(psi_container,
                                constraint_data,
@@ -126,7 +126,7 @@ function activepower_constraints!(psi_container::PSIContainer,
         limits = (min = 0.0, max = PSY.get_activepowerlimits(PSY.get_tech(d)).max)
         name = PSY.get_name(d)
         constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        _device_services(constraint_data[name], d, model)
+        _device_services!(constraint_data[name], d, model)
     end
 
     var_key = Symbol("P_$(T)")
@@ -159,7 +159,7 @@ function reactivepower_constraints!(psi_container::PSIContainer,
         name = PSY.get_name(d)
         limits = PSY.get_reactivepowerlimits(PSY.get_tech(d))
         constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services(constraint_data[name], d, model)
+        #_device_services!(constraint_data[name], d, model)
         # Uncomment when we implement reactive power services
     end
     device_range(psi_container,
@@ -182,7 +182,7 @@ function reactivepower_constraints!(psi_container::PSIContainer,
         limits = PSY.get_reactivepowerlimits(PSY.get_tech(d))
         name = PSY.get_name(d)
         constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services(constraint_data[name], d, model)
+        #_device_services!(constraint_data[name], d, model)
         # Uncomment when we implement reactive power services
     end
     device_semicontinuousrange(psi_container,

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -75,12 +75,13 @@ function activepower_constraints!(psi_container::PSIContainer,
                                  model::DeviceModel{T, <:AbstractThermalDispatchFormulation},
                                  ::Type{<:PM.AbstractPowerModel},
                                  feed_forward::Nothing) where T<:PSY.ThermalGen
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
-        values = PSY.get_activepowerlimits(PSY.get_tech(d))
-        constraint_data[name] = DeviceRange(values, Vector{Symbol}(), Vector{Symbol}())
-        _device_services!(constraint_data[name], d, model)
+        limits = PSY.get_activepowerlimits(PSY.get_tech(d))
+        range_data = DeviceRange(name, limits)
+        _device_services!(range_data, d, model)
+        push!(constraint_data, range_data)
     end
     device_range(psi_container,
                  constraint_data,
@@ -97,12 +98,13 @@ function activepower_constraints!(psi_container::PSIContainer,
                                  model::DeviceModel{T, <:AbstractThermalFormulation},
                                  ::Type{<:PM.AbstractPowerModel},
                                  feed_forward::Nothing) where T<:PSY.ThermalGen
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
     for d in devices
         limits = PSY.get_activepowerlimits(PSY.get_tech(d))
         name = PSY.get_name(d)
-        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        _device_services!(constraint_data[name], d, model)
+        range_data = DeviceRange(name, limits)
+        _device_services!(range_data, d, model)
+        push!(constraint_data, range_data)
     end
     device_semicontinuousrange(psi_container,
                                constraint_data,
@@ -121,12 +123,13 @@ function activepower_constraints!(psi_container::PSIContainer,
                                   model::DeviceModel{T, ThermalDispatchNoMin},
                                   ::Type{<:PM.AbstractPowerModel},
                                   feed_forward::Nothing) where T<:PSY.ThermalGen
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
     for d in devices
         limits = (min = 0.0, max = PSY.get_activepowerlimits(PSY.get_tech(d)).max)
         name = PSY.get_name(d)
-        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        _device_services!(constraint_data[name], d, model)
+        range_data = DeviceRange(name, limits)
+        _device_services!(range_data, d, model)
+        push!(constraint_data, range_data)
     end
 
     var_key = Symbol("P_$(T)")
@@ -154,13 +157,14 @@ function reactivepower_constraints!(psi_container::PSIContainer,
                                    model::DeviceModel{T, <:AbstractThermalDispatchFormulation},
                                    ::Type{<:PM.AbstractPowerModel},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where T<:PSY.ThermalGen
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
     for d in devices
         name = PSY.get_name(d)
         limits = PSY.get_reactivepowerlimits(PSY.get_tech(d))
-        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services!(constraint_data[name], d, model)
+        range_data = DeviceRange(name, limits)
+        #_device_services!(range_data, d, model)
         # Uncomment when we implement reactive power services
+        push!(constraint_data, range_data)
     end
     device_range(psi_container,
                  constraint_data,
@@ -177,13 +181,14 @@ function reactivepower_constraints!(psi_container::PSIContainer,
                                    model::DeviceModel{T, <:AbstractThermalFormulation},
                                    ::Type{<:PM.AbstractPowerModel},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where T<:PSY.ThermalGen
-    constraint_data = Dict{String, DeviceRange}()
+    constraint_data = Vector{DeviceRange}()
     for d in devices
         limits = PSY.get_reactivepowerlimits(PSY.get_tech(d))
         name = PSY.get_name(d)
-        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
-        #_device_services!(constraint_data[name], d, model)
+        range_data = DeviceRange(name, limits)
+        #_device_services!(range_data, d, model)
         # Uncomment when we implement reactive power services
+        push!(constraint_data, range_data)
     end
     device_semicontinuousrange(psi_container,
                                constraint_data,

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -75,11 +75,12 @@ function activepower_constraints!(psi_container::PSIContainer,
                                  model::DeviceModel{T, <:AbstractThermalDispatchFormulation},
                                  ::Type{<:PM.AbstractPowerModel},
                                  feed_forward::Nothing) where T<:PSY.ThermalGen
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data.values[ix] = PSY.get_activepowerlimits(PSY.get_tech(d))
-        constraint_data.names[ix] = PSY.get_name(d)
-        _device_services(constraint_data, ix, d, model)
+    constraint_data = Dict{String, DeviceRange}()
+    for d in devices
+        name = PSY.get_name(d)
+        values = PSY.get_activepowerlimits(PSY.get_tech(d))
+        constraint_data[name] = DeviceRange(values, Vector{Symbol}(), Vector{Symbol}())
+        _device_services(constraint_data[name], d, model)
     end
     device_range(psi_container,
                  constraint_data,
@@ -96,11 +97,12 @@ function activepower_constraints!(psi_container::PSIContainer,
                                  model::DeviceModel{T, <:AbstractThermalFormulation},
                                  ::Type{<:PM.AbstractPowerModel},
                                  feed_forward::Nothing) where T<:PSY.ThermalGen
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data.values[ix] = PSY.get_activepowerlimits(PSY.get_tech(d))
-        constraint_data.names[ix] = PSY.get_name(d)
-        _device_services(constraint_data, ix, d, model)
+    constraint_data = Dict{String, DeviceRange}()
+    for d in devices
+        limits = PSY.get_activepowerlimits(PSY.get_tech(d))
+        name = PSY.get_name(d)
+        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
+        _device_services(constraint_data[name], d, model)
     end
     device_semicontinuousrange(psi_container,
                                constraint_data,
@@ -119,12 +121,12 @@ function activepower_constraints!(psi_container::PSIContainer,
                                   model::DeviceModel{T, ThermalDispatchNoMin},
                                   ::Type{<:PM.AbstractPowerModel},
                                   feed_forward::Nothing) where T<:PSY.ThermalGen
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        ub_value = PSY.get_activepowerlimits(PSY.get_tech(d)).max
-        constraint_data.values[ix] = (min=0.0, max=ub_value)
-        constraint_data.names[ix] = PSY.get_name(d)
-        _device_services(constraint_data, ix, d, model)
+    constraint_data = Dict{String, DeviceRange}()
+    for d in devices
+        limits = (min = 0.0, max = PSY.get_activepowerlimits(PSY.get_tech(d)).max)
+        name = PSY.get_name(d)
+        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
+        _device_services(constraint_data[name], d, model)
     end
 
     var_key = Symbol("P_$(T)")
@@ -152,11 +154,12 @@ function reactivepower_constraints!(psi_container::PSIContainer,
                                    model::DeviceModel{T, <:AbstractThermalDispatchFormulation},
                                    ::Type{<:PM.AbstractPowerModel},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where T<:PSY.ThermalGen
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data.values[ix] = PSY.get_reactivepowerlimits(PSY.get_tech(d))
-        constraint_data.names[ix] = PSY.get_name(d)
-        #_device_services(constraint_data, ix, d, model)
+    constraint_data = Dict{String, DeviceRange}()
+    for d in devices
+        name = PSY.get_name(d)
+        limits = PSY.get_reactivepowerlimits(PSY.get_tech(d))
+        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
+        #_device_services(constraint_data[name], d, model)
         # Uncomment when we implement reactive power services
     end
     device_range(psi_container,
@@ -174,11 +177,12 @@ function reactivepower_constraints!(psi_container::PSIContainer,
                                    model::DeviceModel{T, <:AbstractThermalFormulation},
                                    ::Type{<:PM.AbstractPowerModel},
                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where T<:PSY.ThermalGen
-    constraint_data = DeviceRange(length(devices))
-    for (ix, d) in enumerate(devices)
-        constraint_data.values[ix] = PSY.get_reactivepowerlimits(PSY.get_tech(d))
-        constraint_data.names[ix] = PSY.get_name(d)
-        #_device_services(constraint_data, ix, d, model)
+    constraint_data = Dict{String, DeviceRange}()
+    for d in devices
+        limits = PSY.get_reactivepowerlimits(PSY.get_tech(d))
+        name = PSY.get_name(d)
+        constraint_data[name] = DeviceRange(limits, Vector{Symbol}(), Vector{Symbol}())
+        #_device_services(constraint_data[name], d, model)
         # Uncomment when we implement reactive power services
     end
     device_semicontinuousrange(psi_container,

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -98,7 +98,7 @@ function include_service!(constraint_data::DeviceRange,
     return
 end
 
-function _device_services(constraint_data::DeviceRange,
+function _device_services!(constraint_data::DeviceRange,
                           device::D,
                           model::DeviceModel) where D <: PSY.Device
     for service_model in get_services(model)

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -78,39 +78,34 @@ function modify_device_model!(devices_template::Dict{Symbol, DeviceModel},
 end
 
 function include_service!(constraint_data::DeviceRange,
-                          index::Int64,
                           services::Vector{SR},
                           ::ServiceModel{SR, <:AbstractReservesFormulation}) where SR <: PSY.Reserve{PSY.ReserveUp}
         services_ub = Vector{Symbol}(undef, length(services))
         for (ix, service) in enumerate(services)
-            services_ub[ix] = Symbol("$(PSY.get_name(service))_$SR")
+            push!(constraint_data.additional_terms_ub, Symbol("$(PSY.get_name(service))_$SR"))
         end
-        constraint_data.additional_terms_ub[index] = services_ub
     return
 end
 
 function include_service!(constraint_data::DeviceRange,
-                          index::Int64,
                           services::Vector{SR},
                           ::ServiceModel{SR, <:AbstractReservesFormulation}) where SR <: PSY.Reserve{PSY.ReserveDown}
         services_ub = Vector{Symbol}(undef, length(services))
         for (ix, service) in enumerate(services)
-            services_ub[ix] = Symbol("$(PSY.get_name(service))_$SR")
+            #uses the upper bound of the (downward) service requirement to determine a constraint LB
+            push!(constraint_data.additional_terms_lb, Symbol("$(PSY.get_name(service))_$SR"))
         end
-        #uses the upper bound of the (downward) service requirement to determine a constraint LB
-        constraint_data.additional_terms_lb[index] = services_ub
     return
 end
 
 function _device_services(constraint_data::DeviceRange,
-                          index::Int64,
                           device::D,
                           model::DeviceModel) where D <: PSY.Device
     for service_model in get_services(model)
         if PSY.has_service(device, service_model.service_type)
             services = [s for s in PSY.get_services(device) if isa(s, service_model.service_type)]
             @assert !isempty(services)
-            include_service!(constraint_data, index, services, service_model)
+            include_service!(constraint_data, services, service_model)
         end
     end
     return


### PR DESCRIPTION
This PR is a draft to simplify code in [timeseries_constraint.jl](https://github.com/NREL/PowerSimulations.jl/blob/dev0-2/src/devices_models/devices/common/timeseries_constraint.jl). It implements a new container `DeviceTimeSeries` and collapses the construction of time series data and constraint data into a single loop.

TODO:
 - propagate changes to electric_loads.jl