### PR TITLE
change MOF for FileFormats

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -146,7 +146,6 @@ import Dates
 import TimeSeries
 
 #I/O Imports
-import MathOptInterface: FileFormats
 import DataFrames
 import Feather
 import Colors

--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -146,7 +146,7 @@ import Dates
 import TimeSeries
 
 #I/O Imports
-import MathOptFormat
+import MathOptInterface: FileFormats
 import DataFrames
 import Feather
 import Colors

--- a/src/core/definitions.jl
+++ b/src/core/definitions.jl
@@ -13,7 +13,7 @@ const IS = InfrastructureSystems
 const MOI = MathOptInterface
 const MOIU = MathOptInterface.Utilities
 const PJ = ParameterJuMP
-const MOPFM = MathOptFormat.MOF.Model
+const MOPFM = MOI.FileFormats.Model
 const TS = TimeSeries
 
 #Type Alias for JuMP and PJ containers


### PR DESCRIPTION
[MathOptFormat](https://github.com/odow/MathOptFormat.jl) is now deprecated and the functionality is included in MOI. This PR updates PSI. 

This PR includes an update to the TOML files