### PR TITLE
Prevent Travis-CI from timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ addons:
 #before_script: # homebrew for mac
 #  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
 
+script:
+  - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+  - julia --project --color=yes -e "import Pkg; Pkg.build(); Pkg.instantiate()"
+  - julia --project --check-bounds=yes --color=yes -e "if VERSION < v\"0.7.0-DEV.5183\"; Pkg.test(\"${JL_PKG}\", coverage=true); else using Pkg; Pkg.test(coverage=true); end"
+  - kill %1
+  - echo "Test successful."
+
 jobs:
   include:
     - stage: "Documentation"


### PR DESCRIPTION
This line cause this backgrounded process to `sleep` for 9 minutes, and then print "still running" along with the seconds since it started running.

```
while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
```

Anything run after it need not output anything to the console. Once done, `kill %1` will kill the last background process. 

We need to do the above because on Travis any job that hasn't printed anything to the screen in 10 minutes will time out (Any job that is running for more than 50 minutes will be timed out regardless of whether it is printing anything to the screen or not).