### PR TITLE
adding new HydroDispatch

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -41,9 +41,11 @@ export RenewableConstantPowerFactor
 ######## Hydro Formulations ########
 export HydroFixed
 export HydroDispatchRunOfRiver
-export HydroDispatchSeasonalFlow
+export HydroDispatchReservoirFlow
+export HydroDispatchReservoirStorage
 export HydroCommitmentRunOfRiver
-export HydroCommitmentSeasonalFlow
+export HydroCommitmentReservoirFlow
+export HydroCommitmentReservoirStorage
 ######## Renewable Formulations ########
 export BookKeeping
 export BookKeepingwReservation

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -26,7 +26,7 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
 end
 
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
-                           model::DeviceModel{H, HydroDispatchSeasonalFlow},
+                           model::DeviceModel{H, HydroDispatchReservoirFlow},
                            ::Type{S};
                            kwargs...) where {H<:PSY.HydroGen,
                                              S<:PM.AbstractPowerModel}
@@ -43,11 +43,11 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
     #Constraints
     activepower_constraints!(psi_container, devices, model, S, model.feed_forward)
     reactivepower_constraints!(psi_container, devices, model, S, model.feed_forward)
-    budget_constraints!(psi_container, devices, model, S, model.feed_forward)
+    energy_limit_constraints!(psi_container, devices, model, S, model.feed_forward)
     feed_forward!(psi_container, H, model.feed_forward)
 
     #Cost Function
-    cost_function(psi_container, devices, HydroDispatchSeasonalFlow, S)
+    cost_function(psi_container, devices, HydroDispatchReservoirFlow, S)
 
     return
 end
@@ -110,7 +110,7 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
 end
 
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
-                           model::DeviceModel{H, HydroDispatchSeasonalFlow},
+                           model::DeviceModel{H, HydroDispatchReservoirFlow},
                            ::Type{S};
                            kwargs...) where {H<:PSY.HydroGen,
                                              S<:PM.AbstractActivePowerModel}
@@ -125,17 +125,17 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
 
     #Constraints
     activepower_constraints!(psi_container, devices, model, S, model.feed_forward)
-    budget_constraints!(psi_container, devices, model, S, model.feed_forward)
+    energy_limit_constraints!(psi_container, devices, model, S, model.feed_forward)
     feed_forward!(psi_container, H, model.feed_forward)
 
     #Cost Function
-    cost_function(psi_container, devices, HydroDispatchSeasonalFlow, S)
+    cost_function(psi_container, devices, HydroDispatchReservoirFlow, S)
 
     return
 end
 
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
-                           model::DeviceModel{H, HydroDispatchReservoirFlow},
+                           model::DeviceModel{H, HydroDispatchReservoirStorage},
                            ::Type{S};
                            kwargs...) where {H<:PSY.HydroGen,
                                              S<:PM.AbstractActivePowerModel}
@@ -148,6 +148,8 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
     #Variables
     activepower_variables!(psi_container, devices);
     energy_storage_variables!(psi_container, devices)
+    inflow_variables!(psi_container, devices)
+    spillage_variables!(psi_container, devices)
 
     #Initial Conditions
     storage_energy_init(psi_container, devices)
@@ -166,10 +168,9 @@ end
 
 
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
-                           model::DeviceModel{H, D},
+                           model::DeviceModel{H, HydroCommitmentReservoirFlow},
                            ::Type{S};
                            kwargs...) where {H<:PSY.HydroGen,
-                                             D<:AbstractHydroUnitCommitment,
                                              S<:PM.AbstractActivePowerModel}
 
     devices = PSY.get_components(H, sys)

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -36,6 +36,25 @@ function reactivepower_variables!(psi_container::PSIContainer,
     return
 end
 
+function energy_storage_variables!(psi_container::PSIContainer,
+                                  devices::IS.FlattenIteratorWrapper{H}) where H<:PSY.HydroGen
+    add_variable(psi_container,
+                 devices,
+                 Symbol("E_$(H)"),
+                 false;
+                 ub_value = d -> d.storage_capacity,
+                 lb_value = d -> 0.0,
+                 init_value = d -> d.initial_storage)
+
+    add_variable(psi_container,
+                 devices,
+                 Symbol("In_$(H)"),
+                 false;
+                 ub_value = d -> d.inflow,
+                 lb_value = d -> 0.0)
+    return
+end
+
 """
 This function add the variables for power generation commitment to the model
 """
@@ -234,6 +253,121 @@ function activepower_constraints!(psi_container::PSIContainer,
 
     return
 end
+
+######################## output constraints without Time Series ############################
+function _get_inflow_time_series(psi_container::PSIContainer,
+                            devices::IS.FlattenIteratorWrapper{<:PSY.HydroGen},
+                            model::DeviceModel{<:PSY.HydroGen, <:AbstractHydroFormulation},
+                            get_constraint_values::Function = x -> (min = 0.0, max = 0.0))
+    initial_time = model_initial_time(psi_container)
+    use_forecast_data = model_uses_forecasts(psi_container)
+    parameters = model_has_parameters(psi_container)
+    time_steps = model_time_steps(psi_container)
+    
+    constraint_data = Vector{DeviceRange}()
+    inflow_timeseries = Vector{DeviceTimeSeries}()
+
+    for device in devices
+        bus_number = PSY.get_number(PSY.get_bus(device))
+        name = PSY.get_name(device)
+        inflow_energy = PSY.get_infow(device)
+        if use_forecast_data
+            ts_vector = TS.values(PSY.get_data(PSY.get_forecast(PSY.Deterministic,
+                                                                device,
+                                                                initial_time,
+                                                                "get_infow")))
+        else
+            ts_vector = ones(time_steps[end])
+        end
+        range_data = DeviceRange(name, get_constraint_values(device))
+        push!(constraint_data, range_data)
+        # _device_services!(range_data, device, model)
+        push!(inflow_timeseries, DeviceTimeSeries(name, bus_number, inflow_energy, ts_vector,
+                                                 range_data))
+    end
+    return inflow_timeseries, constraint_data
+end
+
+function inflow_constraints!(psi_container::PSIContainer,
+                            devices::IS.FlattenIteratorWrapper{H},
+                            model::DeviceModel{H, <:AbstractHydroDispatchFormulation},
+                            system_formulation::Type{<:PM.AbstractPowerModel},
+                            feed_forward::Union{Nothing, AbstractAffectFeedForward}) where H<:PSY.HydroGen
+
+    return
+end
+
+function inflow_constraints!(psi_container::PSIContainer,
+                            devices::IS.FlattenIteratorWrapper{H},
+                            model::DeviceModel{PSY.HydroDispatch, HydroDispatchSeasonalFlow},
+                            system_formulation::Type{<:PM.AbstractPowerModel},
+                            feed_forward::Union{Nothing, AbstractAffectFeedForward}) where H<:PSY.HydroGen
+    parameters = model_has_parameters(psi_container)
+    use_forecast_data = model_uses_forecasts(psi_container)
+
+    ts_data_inflow, constraint_data = _get_inflow_time_series(psi_container, devices, model,
+                                            x -> (min=0.0, max=PSY.get_inflow(x)))
+
+    if !parameters && !use_forecast_data
+        device_range(psi_container,
+                     constraint_data,
+                     Symbol("inflowrange_$(H)"),
+                     Symbol("In_$(H)"))
+        return
+    end
+
+    if parameters
+        device_timeseries_param_ub(psi_container,
+                            ts_data_inflow,
+                            Symbol("inflowrange_$(H)"),
+                            UpdateRef{H}("get_inflow"),
+                            Symbol("In_$(H)"))
+    else
+        device_timeseries_ub(psi_container,
+                            ts_data_inflow,
+                            Symbol("inflowrange_$(H)"),
+                            Symbol("In_$(H)"))
+    end
+
+    return
+end
+
+###################################################### book keeping constraints ############
+
+function make_efficiency_data(devices::IS.FlattenIteratorWrapper{H}) where {H<:PSY.HydroGen}
+    names = Vector{String}(undef, length(devices))
+    in_out = Vector{InOut}(undef, length(devices))
+
+    for (ix, d) in enumerate(devices)
+        names[ix] = PSY.get_name(d)
+        in_out[ix] = (in = 1.0, out = 1.0) #PSY.get_efficiency(d)
+    end
+
+    return names, in_out
+end
+
+function energy_balance_constraint!(psi_container::PSIContainer,
+                                   devices::IS.FlattenIteratorWrapper{H},
+                                   ::Type{D},
+                                   ::Type{S},
+                                   feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {H<:PSY.HydroGen,
+                                                            D<:AbstractStorageFormulation,
+                                                            S<:PM.AbstractPowerModel}
+    key = ICKey(DeviceEnergy, H)
+    if !(key in keys(psi_container.initial_conditions))
+        throw(IS.DataFormatError("Initial Conditions for $(h) Energy Constraints not in the model"))
+    end
+
+    efficiency_data = make_efficiency_data(devices)
+
+    energy_balance(psi_container,
+                   psi_container.initial_conditions[key],
+                   efficiency_data,
+                   Symbol("energy_balance_$(H)"),
+                   (Symbol("P_$(H)"), Symbol("In_$(H)"), Symbol("E_$(H)")))
+    return
+end
+
 
 ########################## Make initial Conditions for a Model #############################
 function initial_conditions!(psi_container::PSIContainer,

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -4,6 +4,7 @@ abstract type AbstractHydroUnitCommitment <: AbstractHydroFormulation end
 struct HydroFixed <: AbstractHydroFormulation end
 struct HydroDispatchRunOfRiver <: AbstractHydroDispatchFormulation end
 struct HydroDispatchSeasonalFlow <: AbstractHydroDispatchFormulation end
+struct HydroDispatchReservoirFlow <: AbstractHydroDispatchFormulation end
 struct HydroCommitmentRunOfRiver <: AbstractHydroUnitCommitment end
 struct HydroCommitmentSeasonalFlow <: AbstractHydroUnitCommitment end
 
@@ -256,8 +257,8 @@ end
 
 ######################## output constraints without Time Series ############################
 function _get_inflow_time_series(psi_container::PSIContainer,
-                            devices::IS.FlattenIteratorWrapper{<:PSY.HydroGen},
-                            model::DeviceModel{<:PSY.HydroGen, <:AbstractHydroFormulation},
+                            devices::IS.FlattenIteratorWrapper{PSY.HydroDispatch},
+                            model::DeviceModel{PSY.HydroDispatch, <:AbstractHydroFormulation},
                             get_constraint_values::Function = x -> (min = 0.0, max = 0.0))
     initial_time = model_initial_time(psi_container)
     use_forecast_data = model_uses_forecasts(psi_container)
@@ -270,7 +271,7 @@ function _get_inflow_time_series(psi_container::PSIContainer,
     for device in devices
         bus_number = PSY.get_number(PSY.get_bus(device))
         name = PSY.get_name(device)
-        inflow_energy = PSY.get_infow(device)
+        inflow_energy = PSY.get_inflow(device)
         if use_forecast_data
             ts_vector = TS.values(PSY.get_data(PSY.get_forecast(PSY.Deterministic,
                                                                 device,
@@ -299,7 +300,7 @@ end
 
 function inflow_constraints!(psi_container::PSIContainer,
                             devices::IS.FlattenIteratorWrapper{H},
-                            model::DeviceModel{PSY.HydroDispatch, HydroDispatchSeasonalFlow},
+                            model::DeviceModel{PSY.HydroDispatch, HydroDispatchReservoirFlow},
                             system_formulation::Type{<:PM.AbstractPowerModel},
                             feed_forward::Union{Nothing, AbstractAffectFeedForward}) where H<:PSY.HydroGen
     parameters = model_has_parameters(psi_container)
@@ -348,14 +349,21 @@ end
 
 function energy_balance_constraint!(psi_container::PSIContainer,
                                    devices::IS.FlattenIteratorWrapper{H},
-                                   ::Type{D},
-                                   ::Type{S},
-                                   feed_forward::Union{Nothing, AbstractAffectFeedForward}) where {H<:PSY.HydroGen,
-                                                            D<:AbstractStorageFormulation,
-                                                            S<:PM.AbstractPowerModel}
-    key = ICKey(DeviceEnergy, H)
+                                   model::DeviceModel{H, <:AbstractHydroDispatchFormulation},
+                                   system_formulation::Type{<:PM.AbstractPowerModel},
+                                   feed_forward::Union{Nothing, AbstractAffectFeedForward}) where H<:PSY.HydroGen
+
+    return
+end
+
+function energy_balance_constraint!(psi_container::PSIContainer,
+                                   devices::IS.FlattenIteratorWrapper{PSY.HydroDispatch},
+                                   model::DeviceModel{PSY.HydroDispatch, HydroDispatchReservoirFlow},
+                                   system_formulation::Type{<:PM.AbstractPowerModel},
+                                   feed_forward::Union{Nothing, AbstractAffectFeedForward})
+    key = ICKey(DeviceEnergy, PSY.HydroDispatch)
     if !(key in keys(psi_container.initial_conditions))
-        throw(IS.DataFormatError("Initial Conditions for $(h) Energy Constraints not in the model"))
+        throw(IS.DataFormatError("Initial Conditions for $(PSY.HydroDispatch) Energy Constraints not in the model"))
     end
 
     efficiency_data = make_efficiency_data(devices)
@@ -363,8 +371,8 @@ function energy_balance_constraint!(psi_container::PSIContainer,
     energy_balance(psi_container,
                    psi_container.initial_conditions[key],
                    efficiency_data,
-                   Symbol("energy_balance_$(H)"),
-                   (Symbol("P_$(H)"), Symbol("In_$(H)"), Symbol("E_$(H)")))
+                   Symbol("energy_balance_$(PSY.HydroDispatch)"),
+                   (Symbol("P_$(PSY.HydroDispatch)"), Symbol("In_$(PSY.HydroDispatch)"), Symbol("E_$(PSY.HydroDispatch)")))
     return
 end
 

--- a/src/routines/stage_update.jl
+++ b/src/routines/stage_update.jl
@@ -69,7 +69,7 @@ function _intial_conditions_update!(initial_condition_key::ICKey,
         ini_cond_chronolgy = get_ini_cond_chronology(sim, stage_number)
     # Updates the next stage in the same step. Uses the same chronology as intra_stage
     elseif intra_stage_update
-        from_stage = sim.stages[stage_number-1]
+        from_stage = get_stage(sim, stage_number-1)
         ini_cond_chronolgy = current_stage.internal.chronolgy_dict[stage_number-1]
     # Update is done on the current stage
     elseif inner_stage_update

--- a/test/test_device_hydro_generation_constructors.jl
+++ b/test/test_device_hydro_generation_constructors.jl
@@ -67,8 +67,8 @@ end
 
 end
 
-@testset "Hydro DCPLossLess HydroDispatch with HydroDispatchSeasonalFlow Formulations" begin
-    model = DeviceModel(HydroDispatch, HydroDispatchSeasonalFlow)
+@testset "Hydro DCPLossLess HydroDispatch with HydroDispatchReservoirFlow Formulations" begin
+    model = DeviceModel(HydroDispatch, HydroDispatchReservoirFlow)
 
     # Parameters Testing
     op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hy_uc; use_parameters = true)
@@ -125,8 +125,8 @@ end
 
 end
 
-@testset "Hydro DCPLossLess HydroDispatch with HydroCommitmentSeasonalFlow Formulations" begin
-    model = DeviceModel(HydroDispatch, HydroCommitmentSeasonalFlow)
+@testset "Hydro DCPLossLess HydroDispatch with HydroCommitmentReservoirStorage Formulations" begin
+    model = DeviceModel(HydroDispatch, HydroCommitmentReservoirStorage)
 
     # Parameters Testing
     op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_parameters = true)

--- a/test/test_utils/operations_problem_templates.jl
+++ b/test/test_utils/operations_problem_templates.jl
@@ -45,7 +45,7 @@ devices = Dict(:Generators => DeviceModel(ThermalStandard, ThermalDispatchNoMin)
                                     :Ren => DeviceModel(RenewableDispatch, RenewableFullDispatch),
                                     :Loads =>  DeviceModel(PowerLoad, StaticPowerLoad),
                                     :ILoads =>  DeviceModel(InterruptibleLoad, DispatchablePowerLoad),
-                                    :HydroDispatch => DeviceModel(HydroDispatch, HydroDispatchSeasonalFlow),
+                                    :HydroDispatch => DeviceModel(HydroDispatch, HydroDispatchReservoirFlow),
                                     )
 template_hydro_ed= OperationsProblemTemplate(CopperPlatePowerModel, devices, branches, services);
 #=


### PR DESCRIPTION
- Adding new formulation for `HydroDispatch` which can track energy stored in reservoir, account for inflow and spillage.
- The new formulation is called `HydroDispatchReservoirFlow` (can be named something else), the need for this emerges if we apply energy balance constraint to reservoir storage then the energy limit constraint shouldn't be applied.
- If a energy limits need to be applied, if should be enforced on the `E_HydroDispatch` variable.