### PR TITLE
Updating Hydro Formulations

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -41,9 +41,11 @@ export RenewableConstantPowerFactor
 ######## Hydro Formulations ########
 export HydroFixed
 export HydroDispatchRunOfRiver
-export HydroDispatchSeasonalFlow
+export HydroDispatchReservoirFlow
+export HydroDispatchReservoirStorage
 export HydroCommitmentRunOfRiver
-export HydroCommitmentSeasonalFlow
+export HydroCommitmentReservoirFlow
+export HydroCommitmentReservoirStorage
 ######## Renewable Formulations ########
 export BookKeeping
 export BookKeepingwReservation

--- a/src/core/definitions.jl
+++ b/src/core/definitions.jl
@@ -61,6 +61,8 @@ const START = "Start"
 const STOP = "Stop"
 const THETA = "theta"
 const VM = "Vm"
+const INFLOW = "In"
+const SPILLAGE = "Sp"
 
 # Constraints
 const ACTIVE = "active"
@@ -93,3 +95,4 @@ const RATE_LIMIT_TF = "RateLimitTF"
 const REACTIVE = "reactive"
 const REACTIVE_RANGE = "reactiverange"
 const REQUIREMENT = "requirement"
+const INFLOW_RANGE = "inflowrange"

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -26,7 +26,7 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
 end
 
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
-                           model::DeviceModel{H, HydroDispatchSeasonalFlow},
+                           model::DeviceModel{H, HydroDispatchReservoirFlow},
                            ::Type{S};
                            kwargs...) where {H<:PSY.HydroGen,
                                              S<:PM.AbstractPowerModel}
@@ -43,11 +43,11 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
     #Constraints
     activepower_constraints!(psi_container, devices, model, S, model.feed_forward)
     reactivepower_constraints!(psi_container, devices, model, S, model.feed_forward)
-    budget_constraints!(psi_container, devices, model, S, model.feed_forward)
+    energy_limit_constraints!(psi_container, devices, model, S, model.feed_forward)
     feed_forward!(psi_container, H, model.feed_forward)
 
     #Cost Function
-    cost_function(psi_container, devices, HydroDispatchSeasonalFlow, S)
+    cost_function(psi_container, devices, HydroDispatchReservoirFlow, S)
 
     return
 end
@@ -110,7 +110,7 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
 end
 
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
-                           model::DeviceModel{H, HydroDispatchSeasonalFlow},
+                           model::DeviceModel{H, HydroDispatchReservoirFlow},
                            ::Type{S};
                            kwargs...) where {H<:PSY.HydroGen,
                                              S<:PM.AbstractActivePowerModel}
@@ -125,15 +125,46 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
 
     #Constraints
     activepower_constraints!(psi_container, devices, model, S, model.feed_forward)
-    budget_constraints!(psi_container, devices, model, S, model.feed_forward)
+    energy_limit_constraints!(psi_container, devices, model, S, model.feed_forward)
     feed_forward!(psi_container, H, model.feed_forward)
 
     #Cost Function
-    cost_function(psi_container, devices, HydroDispatchSeasonalFlow, S)
+    cost_function(psi_container, devices, HydroDispatchReservoirFlow, S)
 
     return
 end
 
+function construct_device!(psi_container::PSIContainer, sys::PSY.System,
+                           model::DeviceModel{H, HydroDispatchReservoirStorage},
+                           ::Type{S};
+                           kwargs...) where {H<:PSY.HydroGen,
+                                             S<:PM.AbstractActivePowerModel}
+    devices = PSY.get_components(H, sys)
+
+    if validate_available_devices(devices, H)
+        return
+    end
+
+    #Variables
+    activepower_variables!(psi_container, devices);
+    energy_storage_variables!(psi_container, devices)
+    inflow_variables!(psi_container, devices)
+    spillage_variables!(psi_container, devices)
+
+    #Initial Conditions
+    storage_energy_init(psi_container, devices)
+
+    #Constraints
+    activepower_constraints!(psi_container, devices, model, S, model.feed_forward)
+    inflow_constraints!(psi_container, devices, model, S, model.feed_forward)
+    energy_balance_constraint!(psi_container, devices, model, S, model.feed_forward)
+    feed_forward!(psi_container, H, model.feed_forward)
+
+    #Cost Function
+    cost_function(psi_container, devices, HydroDispatchReservoirStorage, S)
+
+    return
+end
 
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
                            model::DeviceModel{H, D},

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -217,7 +217,7 @@ end
 function construct_device!(psi_container::PSIContainer, sys::PSY.System,
                            model::DeviceModel{PSY.HydroFix, D},
                            ::Type{S};
-                           kwargs...) where {D<:AbstractHydroFormulation,
+                           kwargs...) where {D<:AbstractHydroUnitCommitment,
                                              S<:PM.AbstractPowerModel}
     @warn("The Formulation $(D) only applies to Dispatchable Hydro, *
                Consider Changing the Device Formulation to HydroFixed")

--- a/src/devices_models/device_constructors/hydrogeneration_constructor.jl
+++ b/src/devices_models/device_constructors/hydrogeneration_constructor.jl
@@ -147,7 +147,7 @@ function construct_device!(psi_container::PSIContainer, sys::PSY.System,
 
     #Variables
     activepower_variables!(psi_container, devices);
-    energy_storage_variables!(psi_container, devices)
+    energy_variables!(psi_container, devices)
     inflow_variables!(psi_container, devices)
     spillage_variables!(psi_container, devices)
 

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -499,9 +499,18 @@ function cost_function(psi_container::PSIContainer,
                        system_formulation::Type{<:PM.AbstractPowerModel}) where D<:AbstractHydroFormulation
     add_to_cost(psi_container,
                 devices,
-                Symbol("P_HydroDispatch"),
+                variable_name(REAL_POWER, PSY.HydroDispatch),
                 :fixed,
                 -1.0)
+
+    return
+end
+
+function cost_function(psi_container::PSIContainer,
+                       devices::IS.FlattenIteratorWrapper{H},
+                       device_formulation::Type{D},
+                       system_formulation::Type{<:PM.AbstractPowerModel}) where {D<:AbstractHydroFormulation,
+                                                                                H<:PSY.HydroGen}
 
     return
 end

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -17,9 +17,9 @@ function activepower_variables!(psi_container::PSIContainer,
                  variable_name(REAL_POWER, H),
                  false,
                  :nodal_balance_active;
-                 lb_value = d -> d.tech.activepowerlimits.min,
-                 ub_value = d -> d.tech.activepowerlimits.max,
-                 init_value = d -> PSY.get_activepower(PSY.get_tech(d)))
+                 lb_value = d -> PSY.get_activepowerlimits(PSY.get_tech(d)).min,
+                 ub_value = d -> PSY.get_activepowerlimits(PSY.get_tech(d)).max,
+                 init_value = d -> PSY.get_activepower(d))
 
     return
 end
@@ -31,9 +31,9 @@ function reactivepower_variables!(psi_container::PSIContainer,
                  variable_name(REACTIVE_POWER, H),
                  false,
                  :nodal_balance_reactive;
-                 ub_value = d -> d.tech.reactivepowerlimits.max,
-                 lb_value = d -> d.tech.reactivepowerlimits.min,
-                 init_value = d -> d.tech.reactivepower)
+                 ub_value = d -> PSY.get_reactivepowerlimits(PSY.get_tech(d)).max,
+                 lb_value = d -> PSY.get_reactivepowerlimits(PSY.get_tech(d)).min,
+                 init_value = d -> PSY.get_reactivepower(d))
 
     return
 end
@@ -44,9 +44,9 @@ function energy_variables!(psi_container::PSIContainer,
                  devices,
                  variable_name(ENERGY, H),
                  false;
-                 ub_value = d -> d.storage_capacity,
+                 ub_value = d -> PSY.get_storage_capacity(d),
                  lb_value = d -> 0.0,
-                 init_value = d -> d.initial_storage)
+                 init_value = d -> PSY.get_initial_storage(d))
 
     return
 end
@@ -57,7 +57,7 @@ function inflow_variables!(psi_container::PSIContainer,
                  devices,
                  variable_name(INFLOW, H),
                  false;
-                 ub_value = d -> d.inflow,
+                 ub_value = d -> PSY.get_inflow(d),
                  lb_value = d -> 0.0)
 
     return
@@ -69,7 +69,7 @@ function spillage_variables!(psi_container::PSIContainer,
                  devices,
                  variable_name(SPILLAGE, H),
                  false;
-                 ub_value = d -> d.inflow,
+                 ub_value = d -> PSY.get_inflow(d),
                  lb_value = d -> 0.0)
 
     return

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -540,25 +540,26 @@ function _get_budget(psi_container::PSIContainer,
     return budget_data
 end
 
-function budget_constraints!(psi_container::PSIContainer,
-    devices::IS.FlattenIteratorWrapper{H},
-    model::DeviceModel{H, <:AbstractHydroDispatchFormulation},
-    system_formulation::Type{<:PM.AbstractPowerModel},
-    feed_forward::IntegralLimitFF) where H<:PSY.HydroGen
+function energy_limit_constraints!(psi_container::PSIContainer,
+                                    devices::IS.FlattenIteratorWrapper{H},
+                                    model::DeviceModel{H, <:AbstractHydroDispatchFormulation},
+                                    system_formulation::Type{<:PM.AbstractPowerModel},
+                                    feed_forward::IntegralLimitFF) where H<:PSY.HydroGen
+    return
 end
 
-function budget_constraints!(psi_container::PSIContainer,
-                    devices::IS.FlattenIteratorWrapper{H},
-                    model::DeviceModel{H, <:AbstractHydroDispatchFormulation},
-                    system_formulation::Type{<:PM.AbstractPowerModel},
-                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where H<:PSY.HydroGen
+function energy_limit_constraints!(psi_container::PSIContainer,
+                                    devices::IS.FlattenIteratorWrapper{H},
+                                    model::DeviceModel{H, <:AbstractHydroDispatchFormulation},
+                                    system_formulation::Type{<:PM.AbstractPowerModel},
+                                    feed_forward::Union{Nothing, AbstractAffectFeedForward}) where H<:PSY.HydroGen
     parameters = model_has_parameters(psi_container)
     budget_data  = _get_budget(psi_container, devices)
     if parameters
         device_budget_param_ub(
             psi_container,
             budget_data,
-            constraint_name(ENERGY_LIMIT, H),  # TODO: better name for this constraint
+            constraint_name(ENERGY_LIMIT, H),
             UpdateRef{H}("get_storage_capacity"),
             variable_name(REAL_POWER, H),
         )
@@ -566,17 +567,17 @@ function budget_constraints!(psi_container::PSIContainer,
         device_budget_ub(
             psi_container,
             budget_data,
-            constraint_name(ENERGY_LIMIT), # TODO: better name for this constraint
+            constraint_name(ENERGY_LIMIT),
             variable_name(REAL_POWER, H),
         )
     end
 end
 
-function device_budget_param_ub(psi_container::PSIContainer,
-                            budget_data::Vector{Tuple{String, Int64, Float64, Vector{Float64}}},
-                            cons_name::Symbol,
-                            param_reference::UpdateRef,
-                            var_name::Symbol)
+function device_energy_limit_param_ub(psi_container::PSIContainer,
+                                    budget_data::Vector{Tuple{String, Int64, Float64, Vector{Float64}}},
+                                    cons_name::Symbol,
+                                    param_reference::UpdateRef,
+                                    var_name::Symbol)
     time_steps = model_time_steps(psi_container)
     variable = get_variable(psi_container, var_name)
     set_name = (r[1] for r in budget_data)
@@ -599,10 +600,10 @@ function device_budget_param_ub(psi_container::PSIContainer,
 end
 
 
-function device_budget_ub(psi_container::PSIContainer,
-                            budget_data::Vector{Tuple{String, Int64, Float64, Vector{Float64}}},
-                            cons_name::Symbol,
-                            var_name::Symbol)
+function device_energy_limit_ub(psi_container::PSIContainer,
+                                budget_data::Vector{Tuple{String, Int64, Float64, Vector{Float64}}},
+                                cons_name::Symbol,
+                                var_name::Symbol)
     time_steps = model_time_steps(psi_container)
     variable = get_variable(psi_container, var_name)
     set_name = (r[1] for r in budget_data)

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -556,7 +556,7 @@ function energy_limit_constraints!(psi_container::PSIContainer,
     parameters = model_has_parameters(psi_container)
     budget_data  = _get_budget(psi_container, devices)
     if parameters
-        device_budget_param_ub(
+        device_energy_limit_param_ub(
             psi_container,
             budget_data,
             constraint_name(ENERGY_LIMIT, H),
@@ -564,7 +564,7 @@ function energy_limit_constraints!(psi_container::PSIContainer,
             variable_name(REAL_POWER, H),
         )
     else
-        device_budget_ub(
+        device_energy_limit_ub(
             psi_container,
             budget_data,
             constraint_name(ENERGY_LIMIT),

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -3,9 +3,11 @@ abstract type AbstractHydroDispatchFormulation <: AbstractHydroFormulation end
 abstract type AbstractHydroUnitCommitment <: AbstractHydroFormulation end
 struct HydroFixed <: AbstractHydroFormulation end
 struct HydroDispatchRunOfRiver <: AbstractHydroDispatchFormulation end
-struct HydroDispatchSeasonalFlow <: AbstractHydroDispatchFormulation end
+struct HydroDispatchReservoirFlow <: AbstractHydroDispatchFormulation end
+struct HydroDispatchReservoirStorage <: AbstractHydroDispatchFormulation end
 struct HydroCommitmentRunOfRiver <: AbstractHydroUnitCommitment end
-struct HydroCommitmentSeasonalFlow <: AbstractHydroUnitCommitment end
+struct HydroCommitmentReservoirFlow <: AbstractHydroUnitCommitment end
+struct HydroCommitmentReservoirStorage <: AbstractHydroUnitCommitment end
 
 ########################### Hydro generation variables #################################
 function activepower_variables!(psi_container::PSIContainer,

--- a/src/devices_models/devices/thermal_generation.jl
+++ b/src/devices_models/devices/thermal_generation.jl
@@ -19,9 +19,9 @@ function activepower_variables!(psi_container::PSIContainer,
                  variable_name(REAL_POWER, T),
                  false,
                  :nodal_balance_active;
-                 ub_value = d -> d.tech.activepowerlimits.max,
-                 lb_value = d -> d.tech.activepowerlimits.min,
-                 init_value = d -> PSY.get_activepower(PSY.get_tech(d)))
+                 ub_value = d -> PSY.get_activepowerlimits(PSY.get_tech(d)).max,
+                 lb_value = d -> PSY.get_activepowerlimits(PSY.get_tech(d)).min,
+                 init_value = d -> PSY.get_activepower(d))
     return
 end
 
@@ -35,9 +35,9 @@ function reactivepower_variables!(psi_container::PSIContainer,
                  variable_name(REACTIVE_POWER, T),
                  false,
                  :nodal_balance_reactive;
-                 ub_value = d -> d.tech.reactivepowerlimits.max,
-                 lb_value = d -> d.tech.reactivepowerlimits.min,
-                 init_value = d -> d.tech.reactivepower)
+                 ub_value = d -> PSY.get_reactivepowerlimits(PSY.get_tech(d)).max,
+                 lb_value = d -> PSY.get_reactivepowerlimits(PSY.get_tech(d)).min,
+                 init_value = d -> PSY.get_reactivepower(d))
     return
 end
 

--- a/src/routines/make_initial_conditions.jl
+++ b/src/routines/make_initial_conditions.jl
@@ -121,6 +121,22 @@ function duration_init(
     return
 end
 
+function storage_energy_init(
+    psi_container::PSIContainer,
+    devices::IS.FlattenIteratorWrapper{T},
+) where {T<:PSY.HydroGen}
+    key = ICKey(DeviceEnergy, T)
+    _make_initial_conditions!(
+        psi_container,
+        devices,
+        ICKey(DeviceEnergy, T),
+        _make_initial_condition_energy,
+        _get_reservoir_energy_value,
+    )
+
+    return
+end
+
 function _make_initial_conditions!(
     psi_container::PSIContainer,
     devices::IS.FlattenIteratorWrapper{T},
@@ -185,6 +201,10 @@ end
 
 function _get_energy_value(device, key)
     return PSY.get_energy(device)
+end
+
+function _get_reservoir_energy_value(device, key)
+    return PSY.get_initial_storage(device)
 end
 
 function _get_active_power_duration_value(dev, key)

--- a/src/routines/make_initial_conditions.jl
+++ b/src/routines/make_initial_conditions.jl
@@ -130,7 +130,7 @@ function storage_energy_init(
         psi_container,
         devices,
         ICKey(DeviceEnergy, T),
-        _make_initial_condition_energy,
+        _make_initial_condition_reservoir_energy,
         _get_reservoir_energy_value,
     )
 
@@ -191,6 +191,16 @@ function _make_initial_condition_energy(psi_container, device, value, cache = no
     )
 end
 
+function _make_initial_condition_reservoir_energy(psi_container, device, value, cache = nothing)
+    return InitialCondition(
+        psi_container,
+        device,
+        _get_ref_reservoir_energy(psi_container),
+        value,
+        cache,
+    )
+end
+
 function _get_active_power_status_value(device, key)
     return PSY.get_activepower(device) > 0 ? 1.0 : 0.0
 end
@@ -224,5 +234,10 @@ end
 
 function _get_ref_energy(psi_container::PSIContainer)
     # "energy" is the field name required by Storage devices.
-    return model_has_parameters(psi_container) ? E : "energy"
+    return model_has_parameters(psi_container) ? ENERGY : "energy"  
+end
+
+function _get_ref_reservoir_energy(psi_container::PSIContainer)
+    # "storage_capacity" is the field name required by HydroDispatch devices.
+    return model_has_parameters(psi_container) ? ENERGY : "storage_capacity"  
 end

--- a/test/test_device_hydro_generation_constructors.jl
+++ b/test/test_device_hydro_generation_constructors.jl
@@ -67,8 +67,8 @@ end
 
 end
 
-@testset "Hydro DCPLossLess HydroDispatch with HydroDispatchSeasonalFlow Formulations" begin
-    model = DeviceModel(HydroDispatch, HydroDispatchSeasonalFlow)
+@testset "Hydro DCPLossLess HydroDispatch with HydroDispatchReservoirFlow Formulations" begin
+    model = DeviceModel(HydroDispatch, HydroDispatchReservoirFlow)
 
     # Parameters Testing
     op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hy_uc; use_parameters = true)
@@ -125,8 +125,8 @@ end
 
 end
 
-@testset "Hydro DCPLossLess HydroDispatch with HydroCommitmentSeasonalFlow Formulations" begin
-    model = DeviceModel(HydroDispatch, HydroCommitmentSeasonalFlow)
+@testset "Hydro DCPLossLess HydroDispatch with HydroCommitmentReservoirlFlow Formulations" begin
+    model = DeviceModel(HydroDispatch, HydroCommitmentReservoirFlow)
 
     # Parameters Testing
     op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_parameters = true)

--- a/test/test_device_hydro_generation_constructors.jl
+++ b/test/test_device_hydro_generation_constructors.jl
@@ -153,3 +153,61 @@ end
     psi_checkobjfun_test(op_problem, GAEVF)
 
 end
+
+@testset "Hydro DCPLossLess HydroDispatch with HydroDispatchReservoirStorage Formulations" begin
+    model = DeviceModel(HydroDispatch, HydroDispatchReservoirStorage)
+
+    # Parameters Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_parameters = true)
+    construct_device!(op_problem, :Hydro, model)
+    moi_tests(op_problem, true, 96, 0, 48, 0, 24, false)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+    # No Parameters Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd)
+    construct_device!(op_problem, :Hydro, model);
+    moi_tests(op_problem, false, 96, 0, 48, 0, 24, false)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+    # No Forecast Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_parameters = true, use_forecast_data = false)
+    construct_device!(op_problem, :Hydro, model);
+    moi_tests(op_problem, true, 4, 0, 2, 0, 1, false)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+    # No Forecast - No Parameters Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_forecast_data = false)
+    construct_device!(op_problem, :Hydro, model);
+    moi_tests(op_problem, false, 4, 0, 2, 2, 1, false)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+end
+
+@testset "Hydro DCPLossLess HydroDispatch with HydroCommitmentReservoirStorage Formulations" begin
+    model = DeviceModel(HydroDispatch, HydroCommitmentReservoirStorage)
+
+    # Parameters Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_parameters = true)
+    construct_device!(op_problem, :Hydro, model)
+    moi_tests(op_problem, true, 96, 0, 72, 0, 24, true)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+    # No Parameters Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd)
+    construct_device!(op_problem, :Hydro, model);
+    moi_tests(op_problem, false, 96, 0, 48, 0, 24, true)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+    # No Forecast Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_parameters = true, use_forecast_data = false)
+    construct_device!(op_problem, :Hydro, model);
+    moi_tests(op_problem, true, 4, 0, 3, 0, 1, true)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+    # No Forecast - No Parameters Testing
+    op_problem = OperationsProblem(TestOpProblem, DCPPowerModel, c_sys5_hyd; use_forecast_data = false)
+    construct_device!(op_problem, :Hydro, model);
+    moi_tests(op_problem, false, 4, 0, 2, 1, 1, true)
+    psi_checkobjfun_test(op_problem, GAEVF)
+
+end

--- a/test/test_utils/get_test_data.jl
+++ b/test/test_utils/get_test_data.jl
@@ -67,6 +67,12 @@ for t in 1:2
    for (ix, h) in enumerate(get_components(HydroGen, c_sys5_hyd))
        add_forecast!(c_sys5_hyd, h, Deterministic("get_rating", hydro_timeseries_DA[t][ix]))
    end
+   for (ix, h) in enumerate(get_components(HydroDispatch, c_sys5_hyd))
+       add_forecast!(c_sys5_hyd, h, Deterministic("get_storage_capacity", hydro_timeseries_DA[t][ix]))
+   end
+   for (ix, h) in enumerate(get_components(HydroDispatch, c_sys5_hyd))
+       add_forecast!(c_sys5_hyd, h, Deterministic("get_inflow", hydro_timeseries_DA[t][ix].*0.8))
+   end
 end
 
 #System with Storage Device

--- a/test/test_utils/operations_problem_templates.jl
+++ b/test/test_utils/operations_problem_templates.jl
@@ -45,7 +45,7 @@ devices = Dict(:Generators => DeviceModel(ThermalStandard, ThermalDispatchNoMin)
                                     :Ren => DeviceModel(RenewableDispatch, RenewableFullDispatch),
                                     :Loads =>  DeviceModel(PowerLoad, StaticPowerLoad),
                                     :ILoads =>  DeviceModel(InterruptibleLoad, DispatchablePowerLoad),
-                                    :HydroDispatch => DeviceModel(HydroDispatch, HydroDispatchSeasonalFlow),
+                                    :HydroDispatch => DeviceModel(HydroDispatch, HydroDispatchReservoirFlow),
                                     )
 template_hydro_ed= OperationsProblemTemplate(CopperPlatePowerModel, devices, branches, services);
 #=


### PR DESCRIPTION
- Adding new formulation for `HydroDispatch` which can track energy stored in reservoir, account for inflow and spillage.
- Changed `HydroDispatchSeasonalFlow` - > `HydroDispatchReservoirFlow`
- The new formulation is called `HydroDispatchReservoirStorage` (can be named something else), the need for this emerges if we apply energy balance constraint to reservoir storage then the energy limit constraint shouldn't be applied.
- Added capability to model HydroFixed as HydroROR