### PR TITLE
changing updateref keys in nodal_expression!

### DIFF
--- a/src/devices_models/devices/electric_loads.jl
+++ b/src/devices_models/devices/electric_loads.jl
@@ -209,7 +209,7 @@ function nodal_expression!(psi_container::PSIContainer,
                         -1.0)
         include_parameters(psi_container,
                         ts_data_reactive,
-                        UpdateRef{L}("get_maxactivepower"),
+                        UpdateRef{L}("get_maxreactivepower"),
                         :nodal_balance_reactive,
                         -1.0)
         return

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -278,11 +278,11 @@ function nodal_expression!(psi_container::PSIContainer,
     if parameters
         include_parameters(psi_container,
                            ts_data_active,
-                           UpdateRef{H}("get_rating"),
+                           UpdateRef{H}("get_maxactivepower"),
                            :nodal_balance_active)
         include_parameters(psi_container,
                            ts_data_reactive,
-                           UpdateRef{H}("get_rating"),
+                           UpdateRef{H}("get_maxreactivepower"),
                            :nodal_balance_reactive)
         return
     end

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -281,11 +281,11 @@ function nodal_expression!(psi_container::PSIContainer,
     if parameters
         include_parameters(psi_container,
                            ts_data_active,
-                           UpdateRef{H}("get_maxactivepower"),
+                           UpdateRef{H}("get_activepower"),
                            :nodal_balance_active)
         include_parameters(psi_container,
                            ts_data_reactive,
-                           UpdateRef{H}("get_maxreactivepower"),
+                           UpdateRef{H}("get_reactivepower"),
                            :nodal_balance_reactive)
         return
     end

--- a/src/devices_models/devices/hydro_generation.jl
+++ b/src/devices_models/devices/hydro_generation.jl
@@ -116,14 +116,17 @@ function _get_time_series(psi_container::PSIContainer,
         bus_number = PSY.get_number(PSY.get_bus(device))
         name = PSY.get_name(device)
         tech = PSY.get_tech(device)
-        # pf = sin(acos(PSY.get_powerfactor(PSY.get_tech(device))))
-        active_power = use_forecast_data ? PSY.get_rating(tech) : PSY.get_activepower(device)
+        pf = PSY.get_reactivepower(device) / PSY.get_rating(tech)       
         if use_forecast_data
+            active_power = PSY.get_rating(tech)
+            reactive_power = PSY.get_rating(tech) * pf
             ts_vector = TS.values(PSY.get_data(PSY.get_forecast(PSY.Deterministic,
                                                                 device,
                                                                 initial_time,
                                                                 "get_rating")))
         else
+            active_power = PSY.get_activepower(device)
+            reactive_power = PSY.get_reactivepower(device) 
             ts_vector = ones(time_steps[end])
         end
         range_data = DeviceRange(name, get_constraint_values(device))
@@ -131,7 +134,7 @@ function _get_time_series(psi_container::PSIContainer,
         push!(constraint_data, range_data)
         push!(active_timeseries, DeviceTimeSeries(name, bus_number, active_power, ts_vector,
                                                  range_data))
-        push!(reactive_timeseries, DeviceTimeSeries(name, bus_number, active_power,
+        push!(reactive_timeseries, DeviceTimeSeries(name, bus_number, reactive_power,
                                                     ts_vector, range_data))
     end
     return active_timeseries, reactive_timeseries, constraint_data

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -95,8 +95,9 @@ function _get_time_series(psi_container::PSIContainer,
         name = PSY.get_name(device)
         tech = PSY.get_tech(device)
         pf = sin(acos(PSY.get_powerfactor(PSY.get_tech(device))))
-        active_power = use_forecast_data ? PSY.get_rating(tech) : PSY.get_activepower(device)
         if use_forecast_data
+            active_power = PSY.get_rating(tech)
+            reactive_power = PSY.get_rating(tech) * pf
             forecast = PSY.get_forecast(PSY.Deterministic,
                                         device,
                                         initial_time,
@@ -104,6 +105,8 @@ function _get_time_series(psi_container::PSIContainer,
                                         length(time_steps))
             ts_vector = TS.values(PSY.get_data(forecast))
         else
+            active_power = PSY.get_activepower(device)
+            reactive_power = PSY.get_reactivepower(device)
             ts_vector = ones(time_steps[end])
         end
 

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -174,11 +174,11 @@ function nodal_expression!(psi_container::PSIContainer,
     if parameters
         include_parameters(psi_container,
                            ts_data_active,
-                           UpdateRef{R}("get_maxactivepower"),
+                           UpdateRef{R}("get_activepower"),
                            :nodal_balance_active)
         include_parameters(psi_container,
                            ts_data_reactive,
-                           UpdateRef{R}("get_maxreactivepower"),
+                           UpdateRef{R}("get_reactivepower"),
                            :nodal_balance_reactive)
         return
     end

--- a/src/devices_models/devices/renewable_generation.jl
+++ b/src/devices_models/devices/renewable_generation.jl
@@ -171,11 +171,11 @@ function nodal_expression!(psi_container::PSIContainer,
     if parameters
         include_parameters(psi_container,
                            ts_data_active,
-                           UpdateRef{R}("get_rating"),
+                           UpdateRef{R}("get_maxactivepower"),
                            :nodal_balance_active)
         include_parameters(psi_container,
                            ts_data_reactive,
-                           UpdateRef{R}("get_rating"),
+                           UpdateRef{R}("get_maxreactivepower"),
                            :nodal_balance_reactive)
         return
     end


### PR DESCRIPTION
Per email from @daniel-thom:
The function nodal_expression! for each `RenewableGen`, `ThermalGen`, and `HydroGen` does something like the code below:
 ```julia
        include_parameters(canonical,
                        ts_data_active,
                        UpdateRef{L}("get_maxactivepower"),
                        :nodal_balance_active,
                        -1.0)
        include_parameters(canonical,
                        ts_data_reactive,
                        UpdateRef{L}("get_maxactivepower"),
                        :nodal_balance_reactive,
                        -1.0)
```
Because the keys are the same the 2nd parameter container overwrites the first.  This probably mucks up the results.
 