### PR TITLE
Add automated construct device

### DIFF
--- a/src/PowerSimulations.jl
+++ b/src/PowerSimulations.jl
@@ -508,6 +508,7 @@ include("network_models/area_balance_model.jl")
 include("initial_conditions/initialization.jl")
 
 # Device constructors
+include("devices_models/device_constructors/common/constructor.jl")
 include("devices_models/device_constructors/common/constructor_validations.jl")
 include("devices_models/device_constructors/thermalgeneration_constructor.jl")
 include("devices_models/device_constructors/hydrogeneration_constructor.jl")

--- a/src/devices_models/device_constructors/common/constructor.jl
+++ b/src/devices_models/device_constructors/common/constructor.jl
@@ -1,0 +1,39 @@
+function automated_construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    model::DeviceModel{T, U},
+    ::Type{V};
+    parameters = [],
+    variables = [],
+    constraints = [],
+    initial_conditions = [],
+    expressions = [],
+    to_expressions = [],
+    add_initial_conditions = false,
+    add_feedforward_arguments = false,
+    add_cost_function = false,
+    add_constraint_dual = false,
+) where {T <: PSY.Component, U <: AbstractDeviceFormulation, V <: PM.AbstractPowerModel}
+    devices = get_available_components(T, sys)
+
+    for variable_type in variables
+        add_variables!(container, variable_type, devices, U())
+    end
+
+    for (expression_type, variable_type) in to_expressions
+        add_to_expression!(container, expression_type, variable_type, devices, model, V)
+    end
+
+    for expression_type in expressions
+        add_expressions!(container, expression_type, devices, model)
+    end
+
+    for (constraint_type, expression_type) in constraints
+        add_constraints!(container, constraint_type, expression_type, devices, model, V)
+    end
+
+    add_initial_conditions && initial_conditions!(container, devices, U())
+    add_cost_function && cost_function!(container, devices, model, T)
+    add_constraint_dual && add_constraint_dual!(container, sys, model)
+    add_feedforward_arguments && add_feedforward_arguments!(container, model, devices)
+end

--- a/src/devices_models/device_constructors/thermalgeneration_constructor.jl
+++ b/src/devices_models/device_constructors/thermalgeneration_constructor.jl
@@ -44,55 +44,31 @@ function construct_device!(
     D <: AbstractStandardUnitCommitment,
     S <: PM.AbstractPowerModel,
 }
-    devices = get_available_components(T, sys)
-
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
-    add_variables!(container, StartVariable, devices, D())
-    add_variables!(container, StopVariable, devices, D())
-
-    add_variables!(container, TimeDurationOn, devices, D())
-    add_variables!(container, TimeDurationOff, devices, D())
-
-    initial_conditions!(container, devices, D())
-
-    add_to_expression!(
+    automated_construct_device!(
         container,
-        ActivePowerBalance,
-        ActivePowerVariable,
-        devices,
+        sys,
         model,
         S,
-    )
-    add_to_expression!(
-        container,
-        ReactivePowerBalance,
-        ReactivePowerVariable,
-        devices,
-        model,
-        S,
+        variables = [
+            ActivePowerVariable,
+            ReactivePowerVariable,
+            OnVariable,
+            StartVariable,
+            StopVariable,
+            TimeDurationOn,
+            TimeDurationOff,
+        ],
+        to_expressions = [
+            (ActivePowerBalance, ActivePowerVariable),
+            (ReactivePowerBalance, ReactivePowerVariable),
+            (ActivePowerRangeExpressionLB, ActivePowerVariable),
+            (ActivePowerRangeExpressionUB, ActivePowerVariable),
+        ],
+        expressions = [ProductionCostExpression],
+        add_initial_conditions = true,
+        add_feedforward_arguments = true,
     )
 
-    add_expressions!(container, ProductionCostExpression, devices, model)
-
-    add_to_expression!(
-        container,
-        ActivePowerRangeExpressionLB,
-        ActivePowerVariable,
-        devices,
-        model,
-        S,
-    )
-    add_to_expression!(
-        container,
-        ActivePowerRangeExpressionUB,
-        ActivePowerVariable,
-        devices,
-        model,
-        S,
-    )
-    add_feedforward_arguments!(container, model, devices)
     return
 end
 


### PR DESCRIPTION
The construct_device files contains lots of boilerplate code. This is a simple prototype to demo a simplification. Let me know if you find it interesting. I'm uncertain if there are ordering dependencies that are not accounted for here.