### PR TITLE
fix validate eltype undefined variable bug

### DIFF
--- a/src/utils/time_series_utils.jl
+++ b/src/utils/time_series_utils.jl
@@ -52,7 +52,7 @@ function _validate_eltype(::Type{T}, component::PSY.Component, element, msg = ""
     result = _validate_eltype_helper(T, element)
     result || throw(
         ArgumentError(
-            "Expected element type $T but got $(typeof(x)) for $(get_name(component))" *
+            "Expected element type $T but got $(typeof(element)) for $(get_name(component))" *
             msg,
         ),
     )


### PR DESCRIPTION
I'm guessing someone copy-pasted `_validate_eltype_helper(T, x)` from the time series version, but the variable is passed as `element`, not as `x`.