### PR TITLE
load constructor test fixed

### DIFF
--- a/src/devices_models/devices/common/objective_function/market_bid.jl
+++ b/src/devices_models/devices/common/objective_function/market_bid.jl
@@ -143,7 +143,8 @@ function validate_mbc_breakpoints_slopes(device::PSY.StaticInjection, decrementa
     end
     p1 = nothing
     apply_maybe_across_time_series(device, offer_curves) do x
-        _validate_eltype(expected_type, device, x, " offer curves")
+        curve_type = decremental ? "decremental" : "incremental"
+        _validate_eltype(expected_type, device, x, " $curve_type offer curves")
         if decremental
             PSY.is_concave(x) ||
                 throw(

--- a/src/utils/time_series_utils.jl
+++ b/src/utils/time_series_utils.jl
@@ -47,8 +47,6 @@ _validate_eltype(
         )
     end
 
-# FIXME this is messing with test_device_load_constructors.jl:72
-# the offer curves are nothing, so an error gets thrown here, when it expects a later error.
 function _validate_eltype(::Type{T}, component::PSY.Component, element, msg = "") where {T}
     component_name = get_name(component)
     result = _validate_eltype_helper(T, element)

--- a/test/test_device_load_constructors.jl
+++ b/test/test_device_load_constructors.jl
@@ -69,7 +69,7 @@ end
     for m in models, n in networks
         device_model = DeviceModel(InterruptiblePowerLoad, m)
         model = DecisionModel(MockOperationProblem, n, c_sys5_il)
-        @test_throws ErrorException mock_construct_device!(model, device_model)
+        @test_throws ArgumentError mock_construct_device!(model, device_model)
     end
 end
 


### PR DESCRIPTION
Despite going through every place we `throw` something here in PSI, I couldn't figure out exactly which error was being tested. So I switched the test to match the behavior. edit: that's usually an iffy thing to do, but here, it feels fine. The important thing is that an error is thrown