### PR TITLE
add DC power flow in the loop to performance test

### DIFF
--- a/test/performance/performance_test.jl
+++ b/test/performance/performance_test.jl
@@ -14,11 +14,9 @@ using PowerFlows
 
 @info pkgdir(PowerSimulations)
 
-#=
 open("precompile_time.txt", "a") do io
     write(io, "| $(ARGS[1]) | $(precompile_time.time) |\n")
 end
-=#
 
 function set_device_models!(template::ProblemTemplate, uc::Bool = true)
     if uc


### PR DESCRIPTION
Add `power_flow_evaluation = DCPowerFlow()` to the ED network model in the performance test. (I'm not actually doing anything with the results of that power flow, though: e.g. no export, no checking line limits, etc.)