### PR TITLE
fix should_export_dual call

### DIFF
--- a/src/core/store_common.jl
+++ b/src/core/store_common.jl
@@ -50,7 +50,7 @@ function write_model_dual_results!(
         write_result!(store, model_name, key, index, update_timestamp, data)
 
         if export_params !== nothing &&
-           should_export_dual(export_params[:exports], index, model_name, key)
+           should_export_dual(export_params[:exports], update_timestamp, model_name, key)
             horizon_count = export_params[:horizon_count]
             resolution = export_params[:resolution]
             file_type = export_params[:file_type]


### PR DESCRIPTION
Function called is [here](https://github.com/NREL-Sienna/PowerSimulations.jl/blob/main/src/simulation/simulation_results_export.jl#L138): no type signature, but 2nd arg is called `tstamp`. Without it, I get an error about trying to call `isless(Int, DateTime)`.