### PR TITLE
Patch bug 1486

### DIFF
--- a/src/devices_models/devices/source.jl
+++ b/src/devices_models/devices/source.jl
@@ -207,4 +207,4 @@ end
 get_initial_conditions_device_model(
     ::OperationModel,
     model::DeviceModel{PSY.Source, T},
-) where {T <: <:AbstractSourceFormulation} = DeviceModel(PSY.Source, T)
+) where {T <: AbstractSourceFormulation} = DeviceModel(PSY.Source, T)

--- a/test/test_device_source_constructors.jl
+++ b/test/test_device_source_constructors.jl
@@ -102,7 +102,7 @@ end
     transform_single_time_series!(sys, Hour(24), Hour(24))
 
     template = ProblemTemplate(NetworkModel(CopperPlatePowerModel))
-    set_device_model!(template, ThermalStandard, ThermalDispatchNoMin)
+    set_device_model!(template, ThermalStandard, ThermalStandardUnitCommitment)
     set_device_model!(template, PowerLoad, StaticPowerLoad)
     source_model = DeviceModel(
         Source,


### PR DESCRIPTION
Initial approach: for `Source`s, use the same formulation for the initial conditions solve as for the main model. Not unit tested yet but it seems to fix @annacasavant 's repro at #1486 .