### PR TITLE
Fix write_result!() for unidimensional structs with integer (i.e. time step) index. See PSI issue #1505

### DIFF
--- a/src/operation/decision_model_store.jl
+++ b/src/operation/decision_model_store.jl
@@ -105,6 +105,19 @@ function write_result!(
     key::OptimizationContainerKey,
     index::DecisionModelIndexType,
     update_timestamp::Dates.DateTime,
+    array::DenseAxisArray{T, 1, <:Tuple{UnitRange}},
+) where {T}
+    container = getfield(store, get_store_container_type(key))
+    container[key][index] = array
+    return
+end
+
+function write_result!(
+    store::DecisionModelStore,
+    name::Symbol,
+    key::OptimizationContainerKey,
+    index::DecisionModelIndexType,
+    update_timestamp::Dates.DateTime,
     array::DenseAxisArray{T, 3, <:Tuple{Vector{String}, Vector{String}, UnitRange{Int}}},
 ) where {T}
     container = getfield(store, get_store_container_type(key))

--- a/src/utils/jump_utils.jl
+++ b/src/utils/jump_utils.jl
@@ -322,6 +322,29 @@ function to_results_dataframe(
 end
 
 function to_results_dataframe(
+    array::DenseAxisArray{Float64, 1, <:Tuple{IntegerAxis}},
+    ::Nothing,
+    ::Val{TableFormat.LONG},
+)
+    num_rows = length(array.data)
+    time_col = Vector{Int}(undef, num_rows)
+    name_col = Vector{String}(undef, num_rows)
+    row_index = 1
+    name = "Result"
+    for time_index in axes(array, 1)
+        time_col[row_index] = time_index
+        name_col[row_index] = name
+        row_index += 1
+    end
+
+    return DataFrame(
+        :time_index => time_col,
+        :name => name_col,
+        :value => reshape(permutedims(array.data), num_rows),
+    )
+end
+
+function to_results_dataframe(
     array::DenseAxisArray{Float64, 2, <:Tuple{Vector{String}, IntegerAxis}},
     timestamps,
     ::Val{TableFormat.WIDE},


### PR DESCRIPTION
This PR is a patch for issue #1505.

ALthought the issue was reported for slack variables in reserves models, I guess this might be happening also for unidimensional slacks with Int index such as slacks for system/area PowerBalance

- I hardcoded the column name as "Result". LMK if there is a better way to address that.
- I ran all the tests and nothing was broken.