### PR TITLE
add license info to docs

### DIFF
--- a/docs/src/tutorials/pcm_simulation.md
+++ b/docs/src/tutorials/pcm_simulation.md
@@ -32,6 +32,21 @@ relatively relaxed MIP gap (`ratioGap`) setting to improve speed.
 solver = optimizer_with_attributes(HiGHS.Optimizer, "mip_rel_gap" => 0.5)
 ```
 
+!!! note
+    
+    Defining a solver upfront ensures that only one license is requested when using a license-limited solver, such as Gurobi. We can create a environment variable and pass it to the optimizer constructor for shared license use if using such a solver
+    
+    ```julia
+    using Gurobi
+
+    gurobi_env = Gurobi.Env()
+
+    solver = optimizer_with_attributes(() -> Gurobi.Optimizer(gurobi_env),"MIPGap" => 0.01)
+    ```
+
+    Conversely, if a unique optimizer constructor is defined within the SimulationModels for each stage, a separate license will be obtained for each stage.
+
+
 ### Hourly day-ahead system
 
 First, we'll create a `System` with hourly data to represent day-ahead forecasted wind,


### PR DESCRIPTION
Adding specific license info tip to the multi stage docs for user awareness. Necessary to define global gurobi environment at solver creation otherwise a unique solver license is created for each stage.