### PR TITLE
Fix results to dataframe for one-dim arrays

### DIFF
--- a/src/utils/jump_utils.jl
+++ b/src/utils/jump_utils.jl
@@ -253,7 +253,7 @@ function to_results_dataframe(
     ::Val{TableFormat.LONG},
 )
     return DataFrames.DataFrame(
-        :DateTime => [1],
+        :DateTime => ones(Int, length(axes(array, 1))),
         :name => axes(array, 1),
         :value => array.data,
     )


### PR DESCRIPTION
This should fix this issue: https://github.com/NREL-Sienna/StorageSystemsSimulations.jl/issues/70

The problem was that when having more than one component in the vector was creating a DimensionMismatch: 

```julia
key = InfrastructureSystems.Optimization.VariableKey{StorageEnergyShortageVariable, EnergyReservoirStorage}("")
array = 1-dimensional DenseAxisArray{Float64,1,...} with index sets:
    Dimension 1, ["Bat2", "Bat3"]
And data, a 2-element Vector{Float64}:
 0.1
 0.1
┌ Error: Decision Problem solve failed
│   exception =
│    DimensionMismatch: column :DateTime has length 1 and column :name has length 2
│    Stacktrace:
│      [1] DataFrame(columns::Vector{Any}, colindex::DataFrames.Index; copycols::Bool)
│        @ DataFrames ~/.julia/packages/DataFrames/b4w9K/src/dataframe/dataframe.jl:212
│      [2] DataFrame
│        @ ~/.julia/packages/DataFrames/b4w9K/src/dataframe/dataframe.jl:193 [inlined]
│      [3] DataFrame(::Pair{Symbol, Vector{Int64}}, ::Vararg{Pair{Symbol}}; makeunique::Bool, copycols::Bool)
│        @ DataFrames ~/.julia/packages/DataFrames/b4w9K/src/dataframe/dataframe.jl:261
│      [4] DataFrame
│        @ ~/.julia/packages/DataFrames/b4w9K/src/dataframe/dataframe.jl:257 [inlined]
│      [5] to_results_dataframe(array::JuMP.Containers.DenseAxisArray{Float64, 1, Tuple{Vector{String}}, Tuple{JuMP.Containers._AxisLookup{Dict{String, Int64}}}}, timestamps::Nothing, ::Val{TableFormat.LONG = 0})
│        @ PowerSimulations ~/.julia/dev/PowerSimulations/src/utils/jump_utils.jl:255
│      [6] _read_results(model::DecisionModel{GenericOpProblem}, key::InfrastructureSystems.Optimization.VariableKey{StorageEnergyShortageVariable, EnergyReservoirStorage})
│        @ PowerSimulations ~/.julia/dev/PowerSimulations/src/operation/operation_model_interface.jl:346
│      [7] read_variable
│        @ ~/.julia/dev/PowerSimulations/src/operation/operation_model_interface.jl:339 [inlined]
│      [8] (::PowerSimulations.var"#OptimizationProblemResults##2#OptimizationProblemResults##3"{DecisionModel{GenericOpProblem}})(x::InfrastructureSystems.Optimization.VariableKey{StorageEnergyShortageVariable, EnergyReservoirStorage})
│        @ PowerSimulations ./none:-1
│      [9] iterate
│        @ ./generator.jl:48 [inlined]
│     [10] grow_to!(dest::Dict{Any, Any}, itr::Base.Generator{Vector{InfrastructureSystems.Optimization.VariableKey}, PowerSimulations.var"#OptimizationProblemResults##2#OptimizationProblemResults##3"{DecisionModel{GenericOpProblem}}})
│        @ Base ./abstractdict.jl:595
│     [11] dict_with_eltype
│        @ ./abstractdict.jl:649 [inlined]
│     [12] Dict(kv::Base.Generator{Vector{InfrastructureSystems.Optimization.VariableKey}, PowerSimulations.var"#OptimizationProblemResults##2#OptimizationProblemResults##3"{DecisionModel{GenericOpProblem}}})
│        @ Base ./dict.jl:117
│     [13] OptimizationProblemResults(model::DecisionModel{GenericOpProblem})
│        @ PowerSimulations ~/.julia/dev/PowerSimulations/src/operation/problem_results.jl:20
│     [14] (::PowerSimulations.var"#87#88"{Bool, Bool, DecisionModel{GenericOpProblem}, Nothing})()
│        @ PowerSimulations ~/.julia/dev/PowerSimulations/src/operation/decision_model.jl:516
│     [15] with_logstate(f::PowerSimulations.var"#87#88"{Bool, Bool, DecisionModel{GenericOpProblem}, Nothing}, logstate::Base.CoreLogging.LogState)
│        @ Base.CoreLogging ./logging/logging.jl:540
│     [16] with_logger
│        @ ./logging/logging.jl:651 [inlined]
│     [17] solve!(model::DecisionModel{GenericOpProblem}; export_problem_results::Bool, console_level::LogLevel, file_level::LogLevel, disable_timer_outputs::Bool, export_optimization_problem::Bool, kwargs::@Kwargs{})
│        @ PowerSimulations ~/.julia/dev/PowerSimulations/src/operation/decision_model.jl:490
│     [18] solve!(model::DecisionModel{GenericOpProblem})
│        @ PowerSimulations ~/.julia/dev/PowerSimulations/src/operation/decision_model.jl:461

```