### PR TITLE
Fix bugs in AreaBalancePowerModel add_to_expression! functions

### DIFF
--- a/src/devices_models/devices/common/add_to_expression.jl
+++ b/src/devices_models/devices/common/add_to_expression.jl
@@ -885,17 +885,15 @@ function add_to_expression!(
     V <: PSY.TwoTerminalHVDC,
 }
     variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = get_radial_network_reduction(network_model)
+    expression = get_expression(container, T(), PSY.Area)
     for d in devices
         name = PSY.get_name(d)
-        bus_no_ = PSY.get_number(PSY.get_arc(d).to)
-        bus_no = PNM.get_mapped_bus_number(network_reduction, bus_no_)
+        area_name = PSY.get_name(PSY.get_area(PSY.get_arc(d).to))
         for t in get_time_steps(container)
             _add_to_jump_expression!(
-                expression[bus_no, t],
+                expression[area_name, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U(), V, HVDCTwoTerminalDispatch()),
             )
         end
     end
@@ -1120,7 +1118,7 @@ function add_to_expression!(
     W <: Union{AbstractCompactUnitCommitment, ThermalCompactDispatch},
 }
     variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    expression = get_expression(container, T(), PSY.Area)
     for d in devices
         name = PSY.get_name(d)
         bus = PSY.get_bus(d)


### PR DESCRIPTION
Looks like someone copy-pasted too liberally...unless the two terminal hvdc function should actually be using buses instead of areas?

Bug 1: OnVariable/ThermalGen function (line 1123) incorrectly used PSY.ACBus instead of PSY.Area for expression indexing.

Bug 2: FlowActivePowerToFromVariable/TwoTerminalHVDC function had multiple issues:
- Used PSY.ACBus instead of PSY.Area
- Referenced undefined variable `network_reduction` (only `radial_network_reduction` was declared)
- Used undefined type parameter `W` (should be concrete type HVDCTwoTerminalDispatch)
- Used bus-based indexing instead of area-based indexing