### PR TITLE
test breakpoints and slopes in `run_mbc_sim`

### DIFF
--- a/test/test_utils/iec_simulation_utils.jl
+++ b/test/test_utils/iec_simulation_utils.jl
@@ -195,6 +195,9 @@ function run_iec_sim(sys::System, comp_name::String, ::Type{T};
                     expected_sl = get_y_coords(psd)
                     actual_bp = sort(@rsubset(gen_bp, :DateTime == ts), :name2).value
                     actual_sl = sort(@rsubset(gen_sl, :DateTime == ts), :name2).value
+                    # actual may be longer than expected due to padding (see _unwrap_for_param)
+                    @test length(actual_bp) >= length(expected_bp)
+                    @test length(actual_sl) >= length(expected_sl)
                     @test all(isapprox.(actual_bp[1:length(expected_bp)], expected_bp))
                     @test all(isapprox.(actual_sl[1:length(expected_sl)], expected_sl))
                 end

--- a/test/test_utils/mbc_simulation_utils.jl
+++ b/test/test_utils/mbc_simulation_utils.jl
@@ -287,11 +287,11 @@ function run_mbc_sim(
         sl_param_type = PSI.IncrementalPiecewiseLinearSlopeParameter
         oc_getter = get_incremental_offer_curves
     end
+    # Both bp_param and sl_param are SortedDict{DateTime, DataFrame}.
+    # Columns: :DateTime, :name ("Test Unit1"), :name2 ("tranche_1"),
+    # and :value (breakpoints for bp_param, slopes for sl_param).
     bp_param = _maybe_upgrade_to_dict(read_parameter(res, bp_param_type, T))
-    # SortedDict of DateTime => DataFrame
-    # columns: :DateTime, :name ("Test Unit1"), :name2 ("tranche_1"), :value (breakpoint)
     sl_param = _maybe_upgrade_to_dict(read_parameter(res, sl_param_type, T))
-    # same structure, except :value is slope
 
     # We can compare the raw PiecewiseStepData values directly against read_parameter
     # results because: (1) time-variant offer curve time series are always in natural units
@@ -311,6 +311,9 @@ function run_mbc_sim(
                 expected_sl = get_y_coords(psd)
                 actual_bp = sort(@rsubset(gen_bp, :DateTime == ts), :name2).value
                 actual_sl = sort(@rsubset(gen_sl, :DateTime == ts), :name2).value
+                # actual may be longer than expected due to padding (see _unwrap_for_param)
+                @test length(actual_bp) >= length(expected_bp)
+                @test length(actual_sl) >= length(expected_sl)
                 @test all(isapprox.(actual_bp[1:length(expected_bp)], expected_bp))
                 @test all(isapprox.(actual_sl[1:length(expected_sl)], expected_sl))
             end


### PR DESCRIPTION
Close the PSI equivalent of POM issue [30](https://github.com/NREL-Sienna/PowerOperationsModels.jl/issues/30).

(I haven't ported these tests over to POM yet because much of it is multi-timestep. I'll fix it over there for single problems in a separate PR.)