### PR TITLE
Support multiple group reserve services

### DIFF
--- a/src/operation/problem_template.jl
+++ b/src/operation/problem_template.jl
@@ -254,9 +254,9 @@ function _populate_contributing_devices!(template::ProblemTemplate, sys::PSY.Sys
             )
         end
         if isempty(get_contributing_devices_map(service_model))
-            error(
-                "The contributing devices for service $(PSY.get_name(service)) is empty. Add contributing devices to the service in the data to continue.",
-            )
+            @warn "The contributing devices for service $(PSY.get_name(service)) is empty, consider removing the service from the system" _group =
+                LOG_GROUP_SERVICE_CONSTUCTORS
+            continue
         end
     end
     return

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -483,7 +483,7 @@ function add_constraints!(
         component_type = typeof(d)
         name = PSY.get_name(d)
         varstatus = get_variable(container, OnVariable(), component_type)
-        startup_time = PSY.get_time_limits(d).up
+        startup_time = PSY.get_time_limits(d).down
         ramp_limits = _get_ramp_limits(d)
         if reserve_response_time > startup_time
             reserve_limit =

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -23,11 +23,11 @@ function construct_services!(
     isempty(services_template) && return
     incompatible_device_types = get_incompatible_devices(devices_template)
 
-    groupservice = nothing
+    groupservices = Any[]
 
     for (key, service_model) in services_template
-        if get_formulation(service_model) === GroupReserve  # group service needs to be constructed last
-            groupservice = key
+        if get_formulation(service_model) === GroupReserve # group service needs to be constructed last
+            push!(groupservices, key)  
             continue
         end
         isempty(get_contributing_devices(service_model)) && continue
@@ -41,15 +41,18 @@ function construct_services!(
             network_model,
         )
     end
-    groupservice === nothing || construct_service!(
-        container,
-        sys,
-        stage,
-        services_template[groupservice],
-        devices_template,
-        incompatible_device_types,
-        network_model,
-    )
+    for key in groupservices
+        println("setting the service ",key)
+        construct_service!(
+            container,
+            sys,
+            stage,
+            services_template[key],
+            devices_template,
+            incompatible_device_types,
+            network_model,
+        )
+    end
     return
 end
 
@@ -64,10 +67,10 @@ function construct_services!(
     isempty(services_template) && return
     incompatible_device_types = get_incompatible_devices(devices_template)
 
-    groupservice = nothing
+    groupservices = Any[]
     for (key, service_model) in services_template
-        if get_formulation(service_model) === GroupReserve  # group service needs to be constructed last
-            groupservice = key
+        if get_formulation(service_model) === GroupReserve # group service needs to be constructed last
+            push!(groupservices, key)  
             continue
         end
         isempty(get_contributing_devices_map(service_model)) && continue
@@ -81,15 +84,18 @@ function construct_services!(
             network_model,
         )
     end
-    groupservice === nothing || construct_service!(
-        container,
-        sys,
-        stage,
-        services_template[groupservice],
-        devices_template,
-        incompatible_device_types,
-        network_model,
-    )
+    for key in groupservices
+        println("adding the service ",key)
+        construct_service!(
+            container,
+            sys,
+            stage,
+            services_template[key],
+            devices_template,
+            incompatible_device_types,
+            network_model,
+        )
+    end
     return
 end
 

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -1030,3 +1030,86 @@ end
         output_dir = mktempdir(; cleanup = true),
     ) == PSI.ModelBuildStatus.FAILED
 end
+
+@testset "Test Multiple GroupReserve Constraints" begin
+    template = get_thermal_dispatch_template_network()
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve1"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve11"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveDown}, RangeReserve, "Reserve2"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve, "ORDC1"),
+    )
+
+    c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
+    services = get_components(Service, c_sys5_uc)
+    requirement_group1 = 5.0
+    contributing_services = Vector{Service}()
+    for service in services
+        if (typeof(service) <: PSY.VariableReserve{ReserveUp})
+            push!(contributing_services, service)
+        end
+    end
+    groupservice = ConstantReserveGroup{ReserveSymmetric}(;
+        name = "group_reserve_1",
+        available = true,
+        requirement = requirement_group1,
+        ext = Dict{String, Any}(),
+    )
+    add_service!(c_sys5_uc, groupservice, contributing_services)
+
+    contributing_services = Vector{Service}()
+    requirement_group2 = 10.0
+    for service in services
+        if (typeof(service) <: PSY.VariableReserve{ReserveUp}) || (typeof(service) <: PSY.VariableReserve{ReserveDown})
+            push!(contributing_services, service)
+        end
+    end
+    groupservice = ConstantReserveGroup{ReserveSymmetric}(;
+        name = "group_reserve_2",
+        available = true,
+        requirement = requirement_group2,
+        ext = Dict{String, Any}(),
+    )
+    add_service!(c_sys5_uc, groupservice, contributing_services)
+
+    set_service_model!(
+        template,
+        ServiceModel(ConstantReserveGroup{ReserveSymmetric}, GroupReserve),
+    )
+
+    model = DecisionModel(template, c_sys5_uc)
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          PSI.ModelBuildStatus.BUILT
+
+    container = model.internal.container
+
+    group_reserve_key1 = PSI.ConstraintKey(
+        RequirementConstraint,
+        ConstantReserveGroup{ReserveSymmetric},
+        "group_reserve_1",
+    )
+    cons1 = PSI.get_constraint(container, group_reserve_key1)
+
+    group_reserve_key2 = PSI.ConstraintKey(
+        RequirementConstraint,
+        ConstantReserveGroup{ReserveSymmetric},
+        "group_reserve_2",
+    )
+    cons2 = PSI.get_constraint(container, group_reserve_key2)
+
+    @test all((
+        all(JuMP.normalized_rhs.(cons1).data .== requirement_group1),
+        all(JuMP.normalized_rhs.(cons2).data .== requirement_group2),
+    ))
+
+end


### PR DESCRIPTION
This PR includes the following updates:

1. Keep all group reserve keys when adding group reserves
Updated the group reserve handling so that all group reserve keys are retained. This allows multiple group reserves to be added during model build, instead of having later keys overwrite earlier ones.
2. Use minimum down time as a temporary proxy for start-up time
Since ThermalStandard does not currently include a start-up time parameter, this PR temporarily uses the minimum down time as the start-up time.
3. Add a testing case for group reserve
