### PR TITLE
fix test

### DIFF
--- a/src/network_models/power_flow_evaluation.jl
+++ b/src/network_models/power_flow_evaluation.jl
@@ -439,6 +439,9 @@ _update_pf_data_component!(
     t,
     value,
 ) = (pf_data.bus_active_power_injections[index, t] -= value)
+# FlowActivePowerToFromVariable is signed negative when power flows from→to (since
+# `tf_var + ft_var == losses ≥ 0`), so subtracting yields the correct positive
+# injection at the receiving bus.
 _update_pf_data_component!(
     pf_data::PFS.PowerFlowData,
     ::Val{:active_power_hvdc_pst_to_from},
@@ -446,7 +449,7 @@ _update_pf_data_component!(
     index,
     t,
     value,
-) = (pf_data.bus_active_power_injections[index, t] += value)
+) = (pf_data.bus_active_power_injections[index, t] -= value)
 _update_pf_data_component!(
     pf_data::PFS.PowerFlowData,
     ::Val{:active_power_hvdc_pst_from_to},

--- a/test/test_power_flow_in_the_loop.jl
+++ b/test/test_power_flow_in_the_loop.jl
@@ -404,9 +404,8 @@ end
         atol = 1e-9,
         rtol = 0,
     )
-    # take into account losses in the HVDC line here. [Why does the above pass, then?]
+    # verify the line loss curve is exactly 10% so the loss-ratio check below is meaningful
     hvdc_loss_curve = get_loss(hvdc)
-    # check that our hard-coded numbers are correct.
     @assert hvdc_loss_curve isa PSY.LinearCurve
     @assert get_proportional_term(hvdc_loss_curve) == 0.1
     @assert get_constant_term(hvdc_loss_curve) == 0.0
@@ -416,7 +415,7 @@ end
     @test all(ten_percent_loss[nonzeros])
 
     @test isapprox(
-        data.bus_active_power_injections[bus_lookup[get_number(to)], :] * base_power * 0.9,
+        data.bus_active_power_injections[bus_lookup[get_number(to)], :] * base_power,
         -1 .* to_from,
         atol = 1e-9,
         rtol = 0,


### PR DESCRIPTION
This seems to be an actual bug in the logic for the losses. 

- The source += value for HVDC to-from is a pre-existing bug, dating to commit 254ef571c.                                                                                                    
  - The precedence-list bug (using FlowActivePowerFromToVariable for the to-from category) was also introduced in 254ef571c and was the typo PR #1591 fixed.
  - The two bugs partially cancelled: pre-1591 the to-bus injection got +from_to = +P (wrong magnitude, right sign); post-1591 it gets +to_from = -0.9P (wrong magnitude and wrong      
  sign).                                                                                                                                                                                
  - Luke's test from 2026-01-28 was written against the pre-1591 buggy behavior, with the * 0.9 factor compensating for the magnitude error.  