### PR TITLE
Add time-varying ORDC

### DIFF
--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -1338,6 +1338,36 @@ function _add_param_container!(
     return param_container
 end
 
+function _add_param_container!(
+    container::OptimizationContainer,
+    key::ParameterKey{T, U},
+    attribute::CostFunctionAttributes{V},
+    param_axs,
+    multiplier_axs,
+    additional_axs,
+    time_steps::UnitRange{Int};
+    sparse = false,
+) where {T <: ObjectiveFunctionParameter, U <: PSY.Component, V <: Float64}
+    param_type = Float64
+    if sparse
+        param_array =
+            sparse_container_spec(param_type, multiplier_axs, additional_axs..., time_steps)
+        multiplier_array =
+            sparse_container_spec(Float64, multiplier_axs, additional_axs..., time_steps)
+    else
+        param_array =
+            DenseAxisArray{param_type}(undef, multiplier_axs, additional_axs..., time_steps)
+        multiplier_array =
+            fill!(
+                DenseAxisArray{Float64}(undef, multiplier_axs, additional_axs..., time_steps),
+                NaN,
+            )
+    end
+    param_container = ParameterContainer(attribute, param_array, multiplier_array)
+    _assign_container!(container.parameters, key, param_container)
+    return param_container
+end
+
 function add_param_container!(
     container::OptimizationContainer,
     ::T,
@@ -1356,6 +1386,41 @@ function add_param_container!(
         error("$V can't be abstract: $param_key")
     end
     attributes = TimeSeriesAttributes(V, name)
+    return _add_param_container!(
+        container,
+        param_key,
+        attributes,
+        param_axs,
+        multiplier_axs,
+        additional_axs,
+        time_steps;
+        sparse = sparse,
+    )
+end
+
+function add_param_container!(
+    container::OptimizationContainer,
+    ::T,
+    ::Type{U},
+    ::Type{V},
+    variable_types::Tuple{Vararg{Type}},
+    name::String,
+    param_axs,
+    multiplier_axs,
+    additional_axs,
+    time_steps::UnitRange{Int};
+    sparse = false,
+    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+) where {T <: ObjectiveFunctionParameter, U <: PSY.Component, V <: PSY.TimeSeriesData}
+    param_key = ParameterKey(T, U, meta)
+    if isabstracttype(V)
+        error("$V can't be abstract: $param_key")
+    end
+    attributes = CostFunctionAttributes{Float64}(
+        variable_types,
+        SOSStatusVariable.NO_VARIABLE,
+        false,
+    )
     return _add_param_container!(
         container,
         param_key,

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -1430,7 +1430,7 @@ function add_param_container!(
         container,
         param_key,
         attributes,
-        param_axs,
+        _param_axs,
         multiplier_axs,
         additional_axs,
         time_steps;

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -1342,7 +1342,7 @@ function _add_param_container!(
     container::OptimizationContainer,
     key::ParameterKey{T, U},
     attribute::CostFunctionAttributes{V},
-    param_axs,
+    _param_axs,
     multiplier_axs,
     additional_axs,
     time_steps::UnitRange{Int};
@@ -1410,7 +1410,7 @@ function add_param_container!(
     ::Type{V},
     variable_types::Tuple{Vararg{Type}},
     name::String,
-    param_axs,
+    _param_axs,
     multiplier_axs,
     additional_axs,
     time_steps::UnitRange{Int};

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -1359,7 +1359,12 @@ function _add_param_container!(
             DenseAxisArray{param_type}(undef, multiplier_axs, additional_axs..., time_steps)
         multiplier_array =
             fill!(
-                DenseAxisArray{Float64}(undef, multiplier_axs, additional_axs..., time_steps),
+                DenseAxisArray{Float64}(
+                    undef,
+                    multiplier_axs,
+                    additional_axs...,
+                    time_steps,
+                ),
                 NaN,
             )
     end

--- a/src/devices_models/devices/common/objective_function/market_bid.jl
+++ b/src/devices_models/devices/common/objective_function/market_bid.jl
@@ -603,11 +603,11 @@ Implement the constraints for PWL Block Offer variables for ORDC. That is:
 \\sum_{k\\in\\mathcal{K}} \\delta_{k,t} <= P_{k+1,t}^{max} - P_{k,t}^{max}
 ```
 """
-function _add_pwl_constraint!(
+function _add_pwl_ordc_constraint!(
     container::OptimizationContainer,
     component::T,
     ::U,
-    break_points::Vector{Float64},
+    break_points::Vector{<:JuMPOrFloat},
     sos_status::SOSStatusVariable,
     period::Int,
 ) where {T <: PSY.ReserveDemandCurve, U <: ServiceRequirementVariable}
@@ -615,14 +615,14 @@ function _add_pwl_constraint!(
     variables = get_variable(container, U(), T, name)
     const_container = lazy_container_addition!(
         container,
-        PiecewiseLinearBlockIncrementalOfferConstraint(),
+        PiecewiseLinearBlockDecrementalOfferConstraint(),
         T,
         axes(variables)...;
         meta = name,
     )
     len_cost_data = length(break_points) - 1
     jump_model = get_jump_model(container)
-    pwl_vars = get_variable(container, PiecewiseLinearBlockIncrementalOffer(), T)
+    pwl_vars = get_variable(container, PiecewiseLinearBlockDecrementalOffer(), T)
     const_container[name, period] = JuMP.@constraint(
         jump_model,
         variables[name, period] ==
@@ -694,7 +694,7 @@ function _get_pwl_cost_expression(
     multiplier::Float64,
 ) where {T <: PSY.ReserveDemandCurve}
     name = PSY.get_name(component)
-    pwl_var_container = get_variable(container, PiecewiseLinearBlockIncrementalOffer(), T)
+    pwl_var_container = get_variable(container, PiecewiseLinearBlockDecrementalOffer(), T)
     ordc_cost = JuMP.AffExpr(0.0)
     for (i, slope) in enumerate(slopes_normalized)
         JuMP.add_to_expression!(
@@ -827,44 +827,38 @@ end
 function _add_pwl_term!(
     container::OptimizationContainer,
     component::T,
-    cost_data::PSY.CostCurve{PSY.PiecewiseIncrementalCurve},
+    cost_data::W,
     ::U,
     ::V,
-) where {T <: PSY.Component, U <: VariableType, V <: AbstractServiceFormulation}
+) where {
+    T <: PSY.Component,
+    U <: VariableType,
+    V <: AbstractServiceFormulation,
+    W <: Union{PSY.CostCurve{PSY.PiecewiseIncrementalCurve}, IS.TimeSeriesKey},
+}
     multiplier = objective_function_multiplier(U(), V())
     resolution = get_resolution(container)
     dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
-    base_power = get_base_power(container)
-    value_curve = PSY.get_value_curve(cost_data)
-    power_units = PSY.get_power_units(cost_data)
-    cost_component = PSY.get_function_data(value_curve)
-    device_base_power = PSY.get_base_power(component)
-    data = get_piecewise_curve_per_system_unit(
-        cost_component,
-        power_units,
-        base_power,
-        device_base_power,
-    )
     name = PSY.get_name(component)
     time_steps = get_time_steps(container)
     pwl_cost_expressions = Vector{JuMP.AffExpr}(undef, time_steps[end])
     sos_val = _get_sos_value(container, V, component)
     for t in time_steps
-        break_points = PSY.get_x_coords(data)
+        breakpoints, slopes = _get_reserve_pwl_data(container, component, cost_data, t)
         _add_pwl_variables!(
             container,
-            T,
+            typeof(component),
             name,
             t,
-            length(IS.get_y_coords(data)),
-            PiecewiseLinearBlockIncrementalOffer,
+            length(slopes),
+            PiecewiseLinearBlockDecrementalOffer,
         )
-        _add_pwl_constraint!(container, component, U(), break_points, sos_val, t)
+        _add_pwl_ordc_constraint!(container, component, U(), breakpoints, sos_val, t)
         pwl_cost = _get_pwl_cost_expression(
             container,
             component,
             t,
-            IS.get_y_coords(data),
+            slopes,
             multiplier * dt,
         )
         pwl_cost_expressions[t] = pwl_cost

--- a/src/parameters/add_parameters.jl
+++ b/src/parameters/add_parameters.jl
@@ -90,6 +90,20 @@ end
 function add_parameters!(
     container::OptimizationContainer,
     ::Type{T},
+    service::U,
+    model::ServiceModel{U, V},
+) where {T <: DecrementalPiecewiseLinearSlopeParameter, U <: PSY.Service, V <: AbstractServiceFormulation}
+    if get_rebuild_model(get_settings(container)) &&
+       has_container_key(container, T(), U, PSY.get_name(service))
+        return
+    end
+    _add_parameters!(container, T, service, model)
+    return
+end
+
+function add_parameters!(
+    container::OptimizationContainer,
+    ::Type{T},
     ff::AbstractAffectFeedforward,
     model::DeviceModel{D, W},
     devices::V,
@@ -491,6 +505,15 @@ end
 _get_time_series_name(::T, ::PSY.Component, model::DeviceModel) where {T <: ParameterType} =
     get_time_series_names(model)[T]
 
+_get_time_series_name(::T, ::PSY.Component, model::ServiceModel) where {T <: ParameterType} =
+    get_time_series_names(model)[T]
+
+_get_time_series_name(
+    ::Union{DecrementalPiecewiseLinearSlopeParameter, DecrementalPiecewiseLinearBreakpointParameter},
+    service::PSY.ReserveDemandCurve,
+    ::ServiceModel,
+) = get_name(PSY.get_variable(service))
+
 _get_time_series_name(::StartupCostParameter, device::PSY.Component, ::DeviceModel) =
     get_name(PSY.get_start_up(PSY.get_operation_cost(device)))
 
@@ -560,6 +583,15 @@ _param_to_vars(
 ) =
     (PiecewiseLinearBlockDecrementalOffer,)
 
+_param_to_vars(
+    ::Union{IncrementalPiecewiseLinearSlopeParameter, IncrementalPiecewiseLinearBreakpointParameter},
+    ::AbstractServiceFormulation,
+) = (PiecewiseLinearBlockIncrementalOffer,)
+_param_to_vars(
+    ::Union{DecrementalPiecewiseLinearSlopeParameter, DecrementalPiecewiseLinearBreakpointParameter},
+    ::AbstractServiceFormulation,
+) = (PiecewiseLinearBlockDecrementalOffer,)
+
 # Layer of indirection to handle possible additional axes. Most parameters have just the two
 # usual axes (device, timestamp), but some have a third (e.g., piecewise tranche)
 calc_additional_axes(
@@ -584,12 +616,41 @@ calc_additional_axes(
     W <: AbstractServiceFormulation,
 } where {D <: PSY.Service} = ()
 
+calc_additional_axes(
+    ::OptimizationContainer,
+    ::T,
+    ::U,
+    ::ServiceModel{U, W},
+) where {T <: ParameterType, U <: PSY.Service, W <: AbstractServiceFormulation} = ()
+
+function calc_additional_axes(
+    ::OptimizationContainer,
+    ::P,
+    service::U,
+    ::ServiceModel{U, W},
+) where {P <: AbstractPiecewiseLinearSlopeParameter, U <: PSY.ReserveDemandCurve, W <: AbstractServiceFormulation}
+    curves = PSY.get_variable(service)
+    max_tranches = get_max_tranches(service, curves)
+    return (make_tranche_axis(max_tranches),)
+end
+
+function calc_additional_axes(
+    ::OptimizationContainer,
+    ::P,
+    service::U,
+    ::ServiceModel{U, W},
+) where {P <: AbstractPiecewiseLinearBreakpointParameter, U <: PSY.ReserveDemandCurve, W <: AbstractServiceFormulation}
+    curves = PSY.get_variable(service)
+    max_tranches = get_max_tranches(service, curves)
+    return (make_tranche_axis(max_tranches + 1),)
+end
+
 _get_max_tranches(data::Vector{IS.PiecewiseStepData}) = maximum(length.(data))
 _get_max_tranches(data::TimeSeries.TimeArray) = _get_max_tranches(values(data))
 _get_max_tranches(data::AbstractDict) = maximum(_get_max_tranches.(values(data)))
 
 # Iterate through all periods of a piecewise time series and return the maximum number of tranches
-function get_max_tranches(device::PSY.Device, piecewise_ts::IS.TimeSeriesKey)
+function get_max_tranches(device::PSY.Component, piecewise_ts::IS.TimeSeriesKey)
     data = PSY.get_data(PSY.get_time_series(device, piecewise_ts))
     max_tranches = _get_max_tranches(data)
     return max_tranches
@@ -776,7 +837,7 @@ function _add_parameters!(
     if !(ts_type <: Union{PSY.AbstractDeterministic, PSY.StaticTimeSeries})
         error("add_parameters! for TimeSeriesParameter is not compatible with $ts_type")
     end
-    ts_name = get_time_series_names(model)[T]
+    ts_name = _get_time_series_name(T(), service, model)
     time_steps = get_time_steps(container)
     name = PSY.get_name(service)
     model_interval = get_interval(get_settings(container))
@@ -790,7 +851,7 @@ function _add_parameters!(
         ),
     )
     @debug "adding" T U _group = LOG_GROUP_OPTIMIZATION_CONTAINER
-    additional_axes = calc_additional_axes(container, T(), [service], model)
+    additional_axes = calc_additional_axes(container, T(), service, model)
     parameter_container = add_param_container!(
         container,
         T(),
@@ -806,15 +867,90 @@ function _add_parameters!(
 
     set_subsystem!(get_attributes(parameter_container), get_subsystem(model))
     jump_model = get_jump_model(container)
-    ts_vector = get_time_series(container, service, T(), name; interval = ts_interval)
     multiplier = get_multiplier_value(T(), service, V())
+    raw_ts_vals = get_time_series_initial_values!(container, ts_type, service, ts_name; interval = ts_interval)
+    param_instance = T()
+    ts_vals = _unwrap_for_param.(Ref(param_instance), raw_ts_vals, Ref(additional_axes))
+    all(_size_wrapper.(ts_vals) .== Ref(length.(additional_axes))) || error(
+        "Time series value shape $(_size_wrapper.(ts_vals)) does not match expected " *
+        "additional axis lengths $(length.(additional_axes))",
+    )
     parent_mult = get_multiplier_array_data(parameter_container)
     _set_multiplier_at!(parent_mult, Float64(multiplier), 1)
     parent_param = get_parameter_array_data(parameter_container)
     for t in time_steps
-        _set_parameter_at!(parent_param, jump_model, ts_vector[t], 1, t)
+        _set_parameter_at!(parent_param, jump_model, ts_vals[t], 1, t)
     end
     add_component_name!(get_attributes(parameter_container), name, ts_uuid)
+    return
+end
+
+function _add_parameters!(
+    container::OptimizationContainer,
+    ::Type{T},
+    service::U,
+    model::ServiceModel{U, V},
+) where {
+    T <: DecrementalPiecewiseLinearSlopeParameter,
+    U <: PSY.Service,
+    V <: AbstractServiceFormulation,
+}
+    ts_type = get_default_time_series_type(container)
+    if !(ts_type <: Union{PSY.AbstractDeterministic, PSY.StaticTimeSeries})
+        error(
+            "add_parameters! for DecrementalPiecewiseLinearSlopeParameter is not compatible with $ts_type",
+        )
+    end
+    ts_name = _get_time_series_name(T(), service, model)
+    time_steps = get_time_steps(container)
+    name = PSY.get_name(service)
+    model_interval = get_interval(get_settings(container))
+    ts_interval = model_interval
+    ts_uuid = string(
+        IS.get_time_series_uuid(
+            ts_type,
+            service,
+            ts_name;
+            interval = _to_is_interval(ts_interval),
+        ),
+    )
+    @debug "adding" T U _group = LOG_GROUP_OPTIMIZATION_CONTAINER
+    additional_axes = calc_additional_axes(container, T(), service, model)
+    parameter_container = add_param_container!(
+        container,
+        T(),
+        U,
+        ts_type,
+        _param_to_vars(T(), V()),
+        ts_name,
+        [ts_uuid],
+        [name],
+        additional_axes,
+        time_steps;
+        meta = name,
+    )
+
+    jump_model = get_jump_model(container)
+    multiplier = get_multiplier_value(T(), service, V())
+    raw_ts_vals = get_time_series_initial_values!(
+        container,
+        ts_type,
+        service,
+        ts_name;
+        interval = ts_interval,
+    )
+    param_instance = T()
+    ts_vals = _unwrap_for_param.(Ref(param_instance), raw_ts_vals, Ref(additional_axes))
+    all(_size_wrapper.(ts_vals) .== Ref(length.(additional_axes))) || error(
+        "Time series value shape $(_size_wrapper.(ts_vals)) does not match expected " *
+        "additional axis lengths $(length.(additional_axes))",
+    )
+    parent_mult = get_multiplier_array_data(parameter_container)
+    _set_multiplier_at!(parent_mult, Float64(multiplier), 1)
+    parent_param = get_parameter_array_data(parameter_container)
+    for t in time_steps
+        _set_parameter_at!(parent_param, jump_model, ts_vals[t], 1, t)
+    end
     return
 end
 

--- a/src/parameters/add_parameters.jl
+++ b/src/parameters/add_parameters.jl
@@ -92,7 +92,11 @@ function add_parameters!(
     ::Type{T},
     service::U,
     model::ServiceModel{U, V},
-) where {T <: DecrementalPiecewiseLinearSlopeParameter, U <: PSY.Service, V <: AbstractServiceFormulation}
+) where {
+    T <: DecrementalPiecewiseLinearSlopeParameter,
+    U <: PSY.Service,
+    V <: AbstractServiceFormulation,
+}
     if get_rebuild_model(get_settings(container)) &&
        has_container_key(container, T(), U, PSY.get_name(service))
         return
@@ -505,11 +509,18 @@ end
 _get_time_series_name(::T, ::PSY.Component, model::DeviceModel) where {T <: ParameterType} =
     get_time_series_names(model)[T]
 
-_get_time_series_name(::T, ::PSY.Component, model::ServiceModel) where {T <: ParameterType} =
+_get_time_series_name(
+    ::T,
+    ::PSY.Component,
+    model::ServiceModel,
+) where {T <: ParameterType} =
     get_time_series_names(model)[T]
 
 _get_time_series_name(
-    ::Union{DecrementalPiecewiseLinearSlopeParameter, DecrementalPiecewiseLinearBreakpointParameter},
+    ::Union{
+        DecrementalPiecewiseLinearSlopeParameter,
+        DecrementalPiecewiseLinearBreakpointParameter,
+    },
     service::PSY.ReserveDemandCurve,
     ::ServiceModel,
 ) = get_name(PSY.get_variable(service))
@@ -584,11 +595,17 @@ _param_to_vars(
     (PiecewiseLinearBlockDecrementalOffer,)
 
 _param_to_vars(
-    ::Union{IncrementalPiecewiseLinearSlopeParameter, IncrementalPiecewiseLinearBreakpointParameter},
+    ::Union{
+        IncrementalPiecewiseLinearSlopeParameter,
+        IncrementalPiecewiseLinearBreakpointParameter,
+    },
     ::AbstractServiceFormulation,
 ) = (PiecewiseLinearBlockIncrementalOffer,)
 _param_to_vars(
-    ::Union{DecrementalPiecewiseLinearSlopeParameter, DecrementalPiecewiseLinearBreakpointParameter},
+    ::Union{
+        DecrementalPiecewiseLinearSlopeParameter,
+        DecrementalPiecewiseLinearBreakpointParameter,
+    },
     ::AbstractServiceFormulation,
 ) = (PiecewiseLinearBlockDecrementalOffer,)
 
@@ -628,7 +645,11 @@ function calc_additional_axes(
     ::P,
     service::U,
     ::ServiceModel{U, W},
-) where {P <: AbstractPiecewiseLinearSlopeParameter, U <: PSY.ReserveDemandCurve, W <: AbstractServiceFormulation}
+) where {
+    P <: AbstractPiecewiseLinearSlopeParameter,
+    U <: PSY.ReserveDemandCurve,
+    W <: AbstractServiceFormulation,
+}
     curves = PSY.get_variable(service)
     max_tranches = get_max_tranches(service, curves)
     return (make_tranche_axis(max_tranches),)
@@ -639,7 +660,11 @@ function calc_additional_axes(
     ::P,
     service::U,
     ::ServiceModel{U, W},
-) where {P <: AbstractPiecewiseLinearBreakpointParameter, U <: PSY.ReserveDemandCurve, W <: AbstractServiceFormulation}
+) where {
+    P <: AbstractPiecewiseLinearBreakpointParameter,
+    U <: PSY.ReserveDemandCurve,
+    W <: AbstractServiceFormulation,
+}
     curves = PSY.get_variable(service)
     max_tranches = get_max_tranches(service, curves)
     return (make_tranche_axis(max_tranches + 1),)
@@ -868,7 +893,13 @@ function _add_parameters!(
     set_subsystem!(get_attributes(parameter_container), get_subsystem(model))
     jump_model = get_jump_model(container)
     multiplier = get_multiplier_value(T(), service, V())
-    raw_ts_vals = get_time_series_initial_values!(container, ts_type, service, ts_name; interval = ts_interval)
+    raw_ts_vals = get_time_series_initial_values!(
+        container,
+        ts_type,
+        service,
+        ts_name;
+        interval = ts_interval,
+    )
     param_instance = T()
     ts_vals = _unwrap_for_param.(Ref(param_instance), raw_ts_vals, Ref(additional_axes))
     all(_size_wrapper.(ts_vals) .== Ref(length.(additional_axes))) || error(

--- a/src/parameters/update_container_parameter_values.jl
+++ b/src/parameters/update_container_parameter_values.jl
@@ -217,7 +217,6 @@ function _update_parameter_values!(
     end
 end
 
-
 function _update_parameter_values!(
     parameter_array::DenseAxisArray{T},
     ::ParameterType,
@@ -753,7 +752,6 @@ function update_container_parameter_values!(
     )
     return
 end
-
 
 function update_container_parameter_values!(
     optimization_container::OptimizationContainer,

--- a/src/parameters/update_container_parameter_values.jl
+++ b/src/parameters/update_container_parameter_values.jl
@@ -178,7 +178,7 @@ end
 
 function _update_parameter_values!(
     parameter_array::DenseAxisArray{T},
-    ::ParameterType,
+    ::W,
     attributes::TimeSeriesAttributes{U},
     service::V,
     model::DecisionModel,
@@ -187,8 +187,9 @@ function _update_parameter_values!(
     T <: Union{JuMP.VariableRef, Float64},
     U <: PSY.AbstractDeterministic,
     V <: PSY.Service,
+    W <: ParameterType,
 }
-    initial_forecast_time = get_current_time(model) # Function not well defined for DecisionModels
+    initial_forecast_time = get_current_time(model)
     horizon = get_time_steps(get_optimization_container(model))[end]
     ts_name = get_time_series_name(attributes)
     model_interval = get_interval(get_settings(model))
@@ -203,18 +204,19 @@ function _update_parameter_values!(
         horizon;
         interval = ts_interval,
     )
-    # Hoist the underlying dense storage and resolve the row index once so the
-    # per-time-step writes skip DenseAxisArray's String-keyed axis lookup.
     parent_param = parameter_array.data
     i_param = parameter_array.lookup[1][ts_uuid]
+    additional_axes = lookup_additional_axes(parameter_array)
     for (t, value) in enumerate(ts_vector)
-        if !isfinite(value)
+        unwrapped_value = _unwrap_for_param(W(), value, additional_axes)
+        if !all(isfinite.(unwrapped_value))
             error("The value for the time series $(ts_name) is not finite. \
                   Check that the data in the time series is valid.")
         end
-        _set_param_value_at!(parent_param, value, i_param, t)
+        _set_param_value_at!(parent_param, unwrapped_value, i_param, t)
     end
 end
+
 
 function _update_parameter_values!(
     parameter_array::DenseAxisArray{T},
@@ -739,7 +741,7 @@ function update_container_parameter_values!(
     # Multiplier is only needed for the objective function since `_update_parameter_values!` also updates the objective function
     parameter_multiplier = get_parameter_multiplier_array(optimization_container, key)
     parameter_attributes = get_parameter_attributes(optimization_container, key)
-    _update_parameter_values!(
+    _update_service_cost_parameter_values!(
         parameter_array,
         T(),
         parameter_multiplier,
@@ -747,9 +749,11 @@ function update_container_parameter_values!(
         U,
         model,
         input,
+        key.meta,
     )
     return
 end
+
 
 function update_container_parameter_values!(
     optimization_container::OptimizationContainer,

--- a/src/parameters/update_cost_parameters.jl
+++ b/src/parameters/update_cost_parameters.jl
@@ -202,7 +202,8 @@ function handle_variable_cost_parameter(
         len = horizon,
         count = 1,
     )
-    ts_vector = PSY.read_and_convert_ts(ts, component, initial_forecast_time, horizon, nothing)
+    ts_vector =
+        PSY.read_and_convert_ts(ts, component, initial_forecast_time, horizon, nothing)
     for (t, value::PSY.PiecewiseStepData) in enumerate(TimeSeries.values(ts_vector))
         unwrapped_value =
             _unwrap_for_param(T(), value, lookup_additional_axes(parameter_array))

--- a/src/parameters/update_cost_parameters.jl
+++ b/src/parameters/update_cost_parameters.jl
@@ -39,6 +39,39 @@ function _update_parameter_values!(
     return
 end
 
+function _update_service_cost_parameter_values!(
+    parameter_array::DenseAxisArray,
+    ::T,
+    parameter_multiplier::JuMPFloatArray,
+    attributes::CostFunctionAttributes,
+    ::Type{V},
+    model::DecisionModel,
+    ::DatasetContainer{InMemoryDataset},
+    service_name::String,
+) where {T <: ObjectiveFunctionParameter, V <: PSY.Service}
+    initial_forecast_time = get_current_time(model)
+    time_steps = get_time_steps(get_optimization_container(model))
+    horizon = time_steps[end]
+    container = get_optimization_container(model)
+    is_synchronized(container) && error(
+        "Cannot update $(T) on a synchronized container; objective expressions would " *
+        "be re-augmented and double-counted",
+    )
+    service = PSY.get_component(V, get_system(model), service_name)
+    handle_variable_cost_parameter(
+        T(),
+        service,
+        service_name,
+        parameter_array,
+        parameter_multiplier,
+        attributes,
+        container,
+        initial_forecast_time,
+        horizon,
+    )
+    return
+end
+
 # Only PSY.OfferCurveCost has time-series cost parameters to update; every other
 # OperationalCost is a no-op. OfferCurveCost is dispatched to the specialized
 # methods below (it is more specific than PSY.OperationalCost), so these
@@ -141,6 +174,43 @@ function handle_variable_cost_parameter(
             slope_param,
             container,
             value,  # intentionally passing the PiecewiseStepData here, not the unwrapped
+            parameter_multiplier,
+            attributes,
+            component,
+            t,
+        )
+    end
+    return
+end
+
+function handle_variable_cost_parameter(
+    slope_param::T,
+    component::PSY.ReserveDemandCurve,
+    name,
+    parameter_array,
+    parameter_multiplier,
+    attributes,
+    container,
+    initial_forecast_time,
+    horizon,
+) where {T <: AbstractPiecewiseLinearSlopeParameter}
+    is_time_variant(PSY.get_variable(component)) || return
+    ts = IS.get_time_series(
+        component,
+        PSY.get_variable(component);
+        start_time = initial_forecast_time,
+        len = horizon,
+        count = 1,
+    )
+    ts_vector = PSY.read_and_convert_ts(ts, component, initial_forecast_time, horizon, nothing)
+    for (t, value::PSY.PiecewiseStepData) in enumerate(TimeSeries.values(ts_vector))
+        unwrapped_value =
+            _unwrap_for_param(T(), value, lookup_additional_axes(parameter_array))
+        _set_param_value!(parameter_array, unwrapped_value, name, t)
+        update_variable_cost!(
+            slope_param,
+            container,
+            value,
             parameter_multiplier,
             attributes,
             component,

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -646,7 +646,6 @@ function add_proportional_cost!(
 end
 function process_stepwise_cost_reserve_parameters!(
     container::OptimizationContainer,
-    devices_in,
     model::ServiceModel,
     service::D,
 ) where {D <: PSY.ReserveDemandCurve}

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -43,6 +43,8 @@ get_initial_parameter_value(::VariableValueParameter, d::Type{<:PSY.AbstractRese
 objective_function_multiplier(::ServiceRequirementVariable, ::StepwiseCostReserve) = -1.0
 sos_status(::PSY.ReserveDemandCurve, ::StepwiseCostReserve)=SOSStatusVariable.NO_VARIABLE
 uses_compact_power(::PSY.ReserveDemandCurve, ::StepwiseCostReserve)=false
+get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, d::PSY.ReserveDemandCurve, ::AbstractReservesFormulation) = 1.0
+get_multiplier_value(::AbstractPiecewiseLinearSlopeParameter, d::PSY.ReserveDemandCurve, ::AbstractReservesFormulation) = 1.0
 #! format: on
 
 function get_initial_conditions_service_model(
@@ -534,6 +536,60 @@ function add_variable_cost!(
     return
 end
 
+"""
+Return `(breakpoints, slopes)` for a `ReserveDemandCurve` at time step `t`, reading
+from a static `CostCurve` or from the pre-allocated parameter arrays when the curve
+is time-varying. Mirrors `_get_pwl_data` in `market_bid.jl` for devices.
+"""
+function _get_reserve_pwl_data(
+    container::OptimizationContainer,
+    component::T,
+    variable_cost::Union{PSY.CostCurve{PSY.PiecewiseIncrementalCurve}, IS.TimeSeriesKey},
+    t::Int,
+) where {T <: PSY.ReserveDemandCurve}
+    base_power = get_base_power(container)
+    device_base_power = PSY.get_base_power(component)
+
+    if variable_cost isa PSY.CostCurve{PSY.PiecewiseIncrementalCurve}
+        cost_component = PSY.get_function_data(PSY.get_value_curve(variable_cost))
+        breakpoint_cost_component = PSY.get_x_coords(cost_component)
+        slope_cost_component = PSY.get_y_coords(cost_component)
+        unit_system = PSY.get_power_units(variable_cost)
+    else
+        name = PSY.get_name(component)
+        is_decremental = true
+        SlopeParam = _SLOPE_PARAMS[is_decremental]
+        slope_param_arr = get_parameter_array(container, SlopeParam(), T, name)
+        slope_param_mult = get_parameter_multiplier_array(container, SlopeParam(), T, name)
+        @assert size(slope_param_arr) == size(slope_param_mult)
+        slope_cost_component = slope_param_arr[name, :, t] .* slope_param_mult[name, :, t]
+        slope_cost_component = slope_cost_component.data
+
+        BreakpointParam = _BREAKPOINT_PARAMS[is_decremental]
+        breakpoint_param_container = get_parameter(container, BreakpointParam(), T, name)
+        breakpoint_param_arr = get_parameter_column_refs(breakpoint_param_container, name)
+        breakpoint_param_mult = get_multiplier_array(breakpoint_param_container)
+        @assert size(breakpoint_param_arr) == size(breakpoint_param_mult[name, :, :])
+        breakpoint_cost_component =
+            breakpoint_param_arr[:, t] .* breakpoint_param_mult[name, :, t]
+        breakpoint_cost_component = breakpoint_cost_component.data
+
+        @assert length(slope_cost_component) == length(breakpoint_cost_component) - 1
+        unit_system = PSY.UnitSystem.NATURAL_UNITS
+    end
+
+    breakpoints, slopes = get_piecewise_curve_per_system_unit(
+        breakpoint_cost_component,
+        slope_cost_component,
+        unit_system,
+        base_power,
+        device_base_power,
+    )
+
+    return breakpoints, slopes
+end
+
+
 function _add_variable_cost_to_objective!(
     container::OptimizationContainer,
     ::T,
@@ -542,19 +598,15 @@ function _add_variable_cost_to_objective!(
 ) where {T <: VariableType, U <: StepwiseCostReserve}
     component_name = PSY.get_name(component)
     @debug "PWL Variable Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
-    # If array is full of tuples with zeros return 0.0
     time_steps = get_time_steps(container)
     variable_cost = PSY.get_variable(component)
     if variable_cost isa Nothing
         error("ReserveDemandCurve $(component.name) does not have cost data.")
-    elseif typeof(variable_cost) <: PSY.TimeSeriesKey
-        error(
-            "Timeseries curve for ReserveDemandCurve $(component.name) is not supported yet.",
-        )
     end
 
     pwl_cost_expressions =
         _add_pwl_term!(container, component, variable_cost, T(), U())
+    is_t_variant = is_time_variant(PSY.get_variable(component))
     for t in time_steps
         add_to_expression!(
             container,
@@ -563,10 +615,15 @@ function _add_variable_cost_to_objective!(
             component,
             t,
         )
-        add_to_objective_invariant_expression!(container, pwl_cost_expressions[t])
+        if is_t_variant
+            add_to_objective_variant_expression!(container, pwl_cost_expressions[t])
+        else
+            add_to_objective_invariant_expression!(container, pwl_cost_expressions[t])
+        end
     end
     return
 end
+
 
 function add_proportional_cost!(
     container::OptimizationContainer,
@@ -588,4 +645,17 @@ function add_proportional_cost!(
         )
     end
     return
+end
+function process_stepwise_cost_reserve_parameters!(
+    container::OptimizationContainer,
+    devices_in,
+    model::ServiceModel,
+    service::D,
+) where {D <: PSY.ReserveDemandCurve}
+    for param in (
+        DecrementalPiecewiseLinearBreakpointParameter,
+        DecrementalPiecewiseLinearSlopeParameter,
+    )
+        add_parameters!(container, param, service, model)
+    end
 end

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -589,7 +589,6 @@ function _get_reserve_pwl_data(
     return breakpoints, slopes
 end
 
-
 function _add_variable_cost_to_objective!(
     container::OptimizationContainer,
     ::T,
@@ -623,7 +622,6 @@ function _add_variable_cost_to_objective!(
     end
     return
 end
-
 
 function add_proportional_cost!(
     container::OptimizationContainer,

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -220,6 +220,9 @@ function construct_service!(
     service = PSY.get_component(SR, sys, name)
     !PSY.get_available(service) && return
     contributing_devices = get_contributing_devices(model)
+    if typeof(PSY.get_variable(service)) <: PSY.TimeSeriesKey
+        process_stepwise_cost_reserve_parameters!(container, contributing_devices, model, service)
+    end
     add_variable!(container, ServiceRequirementVariable(), service, StepwiseCostReserve())
     add_variables!(
         container,

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -221,7 +221,12 @@ function construct_service!(
     !PSY.get_available(service) && return
     contributing_devices = get_contributing_devices(model)
     if typeof(PSY.get_variable(service)) <: PSY.TimeSeriesKey
-        process_stepwise_cost_reserve_parameters!(container, contributing_devices, model, service)
+        process_stepwise_cost_reserve_parameters!(
+            container,
+            contributing_devices,
+            model,
+            service,
+        )
     end
     add_variable!(container, ServiceRequirementVariable(), service, StepwiseCostReserve())
     add_variables!(

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -223,7 +223,6 @@ function construct_service!(
     if typeof(PSY.get_variable(service)) <: PSY.TimeSeriesKey
         process_stepwise_cost_reserve_parameters!(
             container,
-            contributing_devices,
             model,
             service,
         )

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -96,7 +96,12 @@ end
     )
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
 
-    model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer, store_variable_names = true)
+    model = DecisionModel(
+        template,
+        c_sys5_uc;
+        optimizer = HiGHS_optimizer,
+        store_variable_names = true,
+    )
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           PSI.ModelBuildStatus.BUILT
     moi_tests(model, 984, 0, 576, 216, 168, true)
@@ -1232,5 +1237,9 @@ end
         res_uc,
         "ServiceRequirementVariable__ReserveDemandCurve__ReserveUp__ORDC1",
     )
-    @test isapprox(sum(ordc1_sol[!, "value"] .- ordc1_sim[25:48, "value"]), 0.0; atol = 1e-12)
+    @test isapprox(
+        sum(ordc1_sol[!, "value"] .- ordc1_sim[25:48, "value"]),
+        0.0;
+        atol = 1e-12,
+    )
 end

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -96,10 +96,45 @@ end
     )
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
 
-    model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer)
+    model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer, store_variable_names = true)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           PSI.ModelBuildStatus.BUILT
     moi_tests(model, 984, 0, 576, 216, 168, true)
+end
+
+@testset "Test Reserves with time varying cost" begin
+    template = get_thermal_standard_uc_template()
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve1"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve11"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveDown}, RangeReserve, "Reserve2"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve, "ORDC1"),
+    )
+    c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
+    model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer)
+    rdc = first(get_components(PSY.ReserveDemandCurve, c_sys5_uc))
+    cost_curve = PSY.get_variable(rdc)
+    cost_curve_ts = make_deterministic_ts(
+        c_sys5_uc,
+        "ordc_cost_curve",
+        PSY.get_function_data(PSY.get_value_curve(cost_curve)),
+        (0.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0),
+    )
+    ts_key = add_time_series!(c_sys5_uc, rdc, cost_curve_ts)
+    set_variable!(rdc, ts_key)
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          PSI.ModelBuildStatus.BUILT
 end
 
 @testset "Test Reserves from Thermal Standard UC with NonSpinningReserve" begin
@@ -1029,4 +1064,173 @@ end
         console_level = Logging.AboveMaxLevel,  # Ignore expected errors.
         output_dir = mktempdir(; cleanup = true),
     ) == PSI.ModelBuildStatus.FAILED
+end
+
+@testset "Test ORDC with TimeSeries" begin
+    c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
+    ordc = first(get_components(PSY.ReserveDemandCurve, c_sys5_uc))
+    ordc_2 = ReserveDemandCurve{ReserveUp}(
+        ordc.variable,
+        "ORDC2",
+        true,
+        ordc.time_frame,
+    )
+    add_service!(c_sys5_uc, ordc_2, get_components(ThermalStandard, c_sys5_uc))
+    ex_incr_x = (0.03, 0.13, 0.07)
+    ex_incr_y = (0.03, 0.13, 0.07)
+    ex_fd = ordc.variable.value_curve.function_data
+    ex_ts2 = make_deterministic_ts(
+        c_sys5_uc,
+        "variable_cost",
+        ex_fd,
+        ex_incr_x,
+        ex_incr_y;
+        override_min_x = 0.0,
+        override_max_x = last(get_x_coords(ex_fd)),
+        create_extra_tranches = true,
+    )
+    im_key2 = add_time_series!(c_sys5_uc, ordc_2, ex_ts2)
+    set_variable!(ordc_2, im_key2)
+    template = ProblemTemplate(NetworkModel(CopperPlatePowerModel; use_slacks = true))
+    set_device_model!(template, ThermalStandard, ThermalDispatchNoMin)
+    set_device_model!(template, PowerLoad, StaticPowerLoad)
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve11"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve1"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveDown}, RangeReserve, "Reserve2"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve, "ORDC1"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve, "ORDC2"),
+    )
+    model = DecisionModel(
+        template,
+        c_sys5_uc;
+        name = "UC",
+        store_variable_names = true,
+        optimizer = HiGHS_optimizer,
+    )
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          PSI.ModelBuildStatus.BUILT
+    @test solve!(model) == PSI.RunStatus.SUCCESSFULLY_FINALIZED
+end
+
+@testset "Test ORDC with TimeSeries Simulation" begin
+    c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
+    ordc = first(get_components(PSY.ReserveDemandCurve, c_sys5_uc))
+    ordc_2 = ReserveDemandCurve{ReserveUp}(
+        ordc.variable,
+        "ORDC2",
+        true,
+        ordc.time_frame,
+    )
+    add_service!(c_sys5_uc, ordc_2, get_components(ThermalStandard, c_sys5_uc))
+    ex_incr_x = (0.03, 0.13, 0.07)
+    ex_incr_y = (0.03, 0.13, 0.07)
+    ex_fd = ordc.variable.value_curve.function_data
+    ex_ts = make_deterministic_ts(
+        c_sys5_uc,
+        "variable_cost",
+        ex_fd,
+        ex_incr_x,
+        ex_incr_y;
+        override_min_x = 0.0,
+        override_max_x = last(get_x_coords(ex_fd)),
+        create_extra_tranches = true,
+    )
+    ex_incr_x = (0.03, 0.13, 0.07)
+    ex_incr_y = (0.02, 0.14, 0.08)
+    ex_ts2 = make_deterministic_ts(
+        c_sys5_uc,
+        "variable_cost",
+        ex_fd,
+        ex_incr_x,
+        ex_incr_y;
+        override_min_x = 0.0,
+        override_max_x = last(get_x_coords(ex_fd)),
+        create_extra_tranches = true,
+    )
+    im_key = add_time_series!(c_sys5_uc, ordc, ex_ts)
+    set_variable!(ordc, im_key)
+    im_key2 = add_time_series!(c_sys5_uc, ordc_2, ex_ts2)
+    set_variable!(ordc_2, im_key2)
+    template = ProblemTemplate(NetworkModel(CopperPlatePowerModel; use_slacks = true))
+    set_device_model!(template, ThermalStandard, ThermalBasicUnitCommitment)
+    set_device_model!(template, PowerLoad, StaticPowerLoad)
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve11"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveUp}, RangeReserve, "Reserve1"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(VariableReserve{ReserveDown}, RangeReserve, "Reserve2"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve, "ORDC1"),
+    )
+    set_service_model!(
+        template,
+        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve, "ORDC2"),
+    )
+    model = DecisionModel(
+        template,
+        c_sys5_uc;
+        name = "UC",
+        store_variable_names = true,
+        optimizer = HiGHS_optimizer,
+        initial_time = DateTime("2024-01-02T00:00:00"),
+    )
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          PSI.ModelBuildStatus.BUILT
+    @test solve!(model) == PSI.RunStatus.SUCCESSFULLY_FINALIZED
+    res = OptimizationProblemResults(model)
+    ordc1_sol = read_variable(
+        res,
+        "ServiceRequirementVariable__ReserveDemandCurve__ReserveUp__ORDC1",
+    )
+    models = SimulationModels([
+        DecisionModel(
+            template,
+            c_sys5_uc;
+            name = "UC",
+            optimizer = HiGHS_optimizer,
+            store_variable_names = true,
+        ),
+    ])
+    test_sequence = SimulationSequence(;
+        models = models,
+        ini_cond_chronology = InterProblemChronology(),
+    )
+    sim = Simulation(;
+        name = "consecutive",
+        steps = 2,
+        models = models,
+        sequence = test_sequence,
+        simulation_folder = mktempdir(; cleanup = true),
+    )
+    @test build!(sim) == PSI.SimulationBuildStatus.BUILT
+    @test execute!(sim) == PSI.RunStatus.SUCCESSFULLY_FINALIZED
+    res_sim = SimulationResults(sim)
+    res_uc = get_decision_problem_results(res_sim, "UC")
+    ordc1_sim = read_realized_variable(
+        res_uc,
+        "ServiceRequirementVariable__ReserveDemandCurve__ReserveUp__ORDC1",
+    )
+    @test isapprox(sum(ordc1_sol[!, "value"] .- ordc1_sim[25:48, "value"]), 0.0; atol = 1e-12)
 end


### PR DESCRIPTION
# Support time-varying piecewise-linear cost curves for ORDC reserves

## Summary
This PR is based on @luke-kiernan's  [ORDC time series branch](https://github.com/Sienna-Platform/PowerSimulations.jl/tree/lk/time-series-ordc) 


`ReserveDemandCurve` services (ORDC) currently only support **static** piecewise-linear cost curves. If the curve is a `TimeSeriesKey`, construction errors out with:

```
Timeseries curve for ReserveDemandCurve <name> is not supported yet.
```

This PR adds support for time-varying PWL ORDC curves — allocation, objective assembly, parameter updates between simulation steps, and tests.

## What changed

**Parameter container plumbing**
- Overloaded `_add_param_container!` / `add_param_container!` for `ObjectiveFunctionParameter` so containers can carry a third axis for PWL tranches in addition to `(component, time)`.
- Added `calc_additional_axes` methods for `AbstractPiecewiseLinearSlopeParameter` and `AbstractPiecewiseLinearBreakpointParameter` on `ReserveDemandCurve`. Slopes get `N` tranches, breakpoints get `N+1`, where `N = get_max_tranches(...)` across the time series.
- Extended `_get_time_series_name` and `add_parameters!` dispatch to `ServiceModel` (previously only wired for `DeviceModel`).
- Generalized `get_max_tranches` to accept `PSY.Component` (was `PSY.Device`).

**Objective function (ORDC PWL)**
- Generalized `_add_pwl_term!` to accept either a static `PSY.CostCurve{PSY.PiecewiseIncrementalCurve}` or an `IS.TimeSeriesKey` via a single `Union` dispatch.
- Added `_get_reserve_pwl_data`, the time-varying counterpart to `_get_pwl_data` for devices. Reads breakpoints/slopes from the parameter arrays at time `t` when the curve is a `TimeSeriesKey`, and falls back to the static path otherwise.
- Renamed `_add_pwl_constraint!` → `_add_pwl_ordc_constraint!` for ORDC and switched it (and `_get_pwl_cost_expression`) from `PiecewiseLinearBlockIncrementalOffer` to `PiecewiseLinearBlockDecrementalOffer`. ORDC is a **demand** curve — price decreases as more reserve is supplied — so the decremental variants are the correct ones; the previous code reused the incremental ones.
- When the ORDC curve is time-variant, the cost expression is now added via `add_to_objective_variant_expression!` instead of the invariant one so it can be refreshed each step.
- Added `get_multiplier_value` methods for `AbstractPiecewiseLinearBreakpointParameter` and `AbstractPiecewiseLinearSlopeParameter` on `ReserveDemandCurve` (return `1.0`) so the generic parameter-add path resolves.

**Parameter updates between steps**
- Updated `_update_parameter_values!` / `update_container_parameter_values!` to iterate over the extra tranche axis.
- Added `_update_service_cost_parameter_values!` and `handle_variable_cost_parameter` in `update_cost_parameters.jl` to push the new ORDC PWL coefficients into the JuMP `ParameterRef`s each simulation step. Without this, containers would be allocated once and never refreshed.

**Constructor**
- `services_constructor.jl` now checks for a `TimeSeriesKey` variable cost on the service and routes to the time-series parameter path instead of the static-curve path.

**Tests**
- Added ORDC time-series tests in `test/test_services_constructor.jl`.