### PR TITLE
Fix lossless HVDC double-counted in power-flow-in-the-loop injections

### DIFF
--- a/src/network_models/power_flow_evaluation.jl
+++ b/src/network_models/power_flow_evaluation.jl
@@ -448,6 +448,18 @@ function add_power_flow_data!(
 end
 
 # How to update the PowerFlowData given a component type. A bit duplicative of code in PowerFlows.jl.
+# Generic forwarder: most categories do not depend on which variable supplied the value, so
+# the entry (variable) type is dropped here. Only the HVDC writers below specialize on it, to
+# distinguish the lossless single-flow variable from the dispatch model's signed From/To pair.
+_update_pf_data_component!(
+    pf_data::PFS.PowerFlowData,
+    category::Val,
+    comp_type::Type,
+    ::Type,
+    index::Int,
+    t::Int,
+    value::Float64,
+) = _update_pf_data_component!(pf_data, category, comp_type, index, t, value)
 _update_pf_data_component!(
     pf_data::PFS.PowerFlowData,
     ::Val{:active_power},
@@ -514,25 +526,48 @@ _update_pf_data_component!(
     t::Int,
     value::Float64,
 ) = (pf_data.bus_magnitude[index, t] = value)
+# HVDC terminal injections are routed into `bus_hvdc_net_power` (mirroring how PowerFlows.jl
+# accumulates native HVDC setpoints), NOT `bus_active_power_injections`. `update_pf_data!`
+# zeroes `bus_hvdc_net_power` (via `clear_injection_data!`) before writing, so the OPF-derived
+# values fully replace the construction-time setpoints rather than double-counting them.
+#
+# At the from bus the flow leaves the network, so it is a negative net injection (`-= value`),
+# regardless of which variable supplied it.
 _update_pf_data_component!(
     pf_data::PFS.PowerFlowData,
     ::Val{:active_power_hvdc_pst_from_to},
     ::Type{<:PSY.TwoTerminalHVDC},
+    ::Type,
     index::Int,
     t::Int,
     value::Float64,
-) = (pf_data.bus_active_power_injections[index, t] -= value)
-# FlowActivePowerToFromVariable is signed negative when power flows from→to (since
-# `tf_var + ft_var == losses ≥ 0`), so subtracting yields the correct positive
-# injection at the receiving bus.
+) = (pf_data.bus_hvdc_net_power[index, t] -= value)
+# At the to bus the sign depends on the formulation:
+#   * HVDCTwoTerminalDispatch supplies the dedicated FlowActivePowerToFromVariable, which is
+#     signed negative when power flows from→to (since `tf_var + ft_var == losses ≥ 0`), so
+#     subtracting yields the correct positive injection at the receiving bus.
 _update_pf_data_component!(
     pf_data::PFS.PowerFlowData,
     ::Val{:active_power_hvdc_pst_to_from},
     ::Type{<:PSY.TwoTerminalHVDC},
+    ::Type{FlowActivePowerToFromVariable},
     index::Int,
     t::Int,
     value::Float64,
-) = (pf_data.bus_active_power_injections[index, t] -= value)
+) = (pf_data.bus_hvdc_net_power[index, t] -= value)
+#   * The lossless/unbounded formulations expose a single FlowActivePowerVariable (positive =
+#     from→to) wired to BOTH terminal categories. The to bus receives the flow, so it is a
+#     positive net injection (`+= value`); using `-= value` here would inject the same sign at
+#     both terminals and create a large phantom imbalance the slack must absorb.
+_update_pf_data_component!(
+    pf_data::PFS.PowerFlowData,
+    ::Val{:active_power_hvdc_pst_to_from},
+    ::Type{<:PSY.TwoTerminalHVDC},
+    ::Type{FlowActivePowerVariable},
+    index::Int,
+    t::Int,
+    value::Float64,
+) = (pf_data.bus_hvdc_net_power[index, t] += value)
 _update_pf_data_component!(
     pf_data::PFS.PowerFlowData,
     ::Val{:active_power_hvdc_pst_from_to},
@@ -631,6 +666,7 @@ function _write_value_to_pf_data!(
                     pf_data,
                     Val(category),
                     get_component_type(key),
+                    get_entry_type(key),
                     index,
                     t,
                     value,

--- a/test/test_power_flow_in_the_loop.jl
+++ b/test/test_power_flow_in_the_loop.jl
@@ -400,8 +400,9 @@ end
     from_to = vd["FlowActivePowerFromToVariable__TwoTerminalGenericHVDCLine"][:, :value]
     to_from = vd["FlowActivePowerToFromVariable__TwoTerminalGenericHVDCLine"][:, :value]
 
+    # HVDC terminal injections are routed into bus_hvdc_net_power, not bus_active_power_injections.
     @test isapprox(
-        data.bus_active_power_injections[bus_lookup[get_number(from)], :] * base_power,
+        data.bus_hvdc_net_power[bus_lookup[get_number(from)], :] * base_power,
         -1 .* from_to,
         atol = 1e-9,
         rtol = 0,
@@ -417,11 +418,90 @@ end
     @test all(ten_percent_loss[nonzeros])
 
     @test isapprox(
-        data.bus_active_power_injections[bus_lookup[get_number(to)], :] * base_power,
+        data.bus_hvdc_net_power[bus_lookup[get_number(to)], :] * base_power,
         -1 .* to_from,
         atol = 1e-9,
         rtol = 0,
     )
+    # The HVDC contributions must NOT leak into bus_active_power_injections (injections at the
+    # HVDC buses were removed above, so anything nonzero there would be a misrouted HVDC term).
+    @test all(
+        iszero,
+        data.bus_active_power_injections[bus_lookup[get_number(from)], :],
+    )
+    @test all(
+        iszero,
+        data.bus_active_power_injections[bus_lookup[get_number(to)], :],
+    )
+end
+
+@testset "lossless generic HVDC with AC PF in the loop" begin
+    # Regression for the lossless single-variable sign bug: the from/to terminals must receive
+    # equal-and-opposite net injections (net zero, since lossless), routed into
+    # bus_hvdc_net_power. The previous code subtracted the single FlowActivePowerVariable at
+    # BOTH terminals, producing a large same-sign phantom injection. Mirrors the dispatch
+    # testset's RTS setup so the HVDC actually carries an inter-area transfer.
+    sys = build_system(PSISystems, "RTS_GMLC_DA_sys")
+
+    hvdc = only(get_components(TwoTerminalGenericHVDCLine, sys))
+    set_loss!(hvdc, LinearCurve(0.0))  # lossless
+    from = get_from(get_arc(hvdc))
+    to = get_to(get_arc(hvdc))
+
+    # remove components that impact total bus power at the HVDC line buses.
+    components = collect(
+        get_components(
+            x -> get_number(get_bus(x)) ∈ (get_number(from), get_number(to)),
+            StaticInjection,
+            sys,
+        ),
+    )
+    foreach(x -> remove_component!(sys, x), components)
+    for bus_name in ["Chifa", "Arne"]
+        set_bustype!(get_component(PSY.ACBus, sys, bus_name), PSY.ACBusTypes.PQ)
+    end
+    set_bustype!(get_component(ACBus, sys, "Arthur"), ACBusTypes.REF)
+
+    template_uc =
+        ProblemTemplate(
+            NetworkModel(PTDFPowerModel; power_flow_evaluation = ACPolarPowerFlow()),
+        )
+    set_device_model!(template_uc, ThermalStandard, ThermalBasicUnitCommitment)
+    set_device_model!(template_uc, RenewableDispatch, RenewableFullDispatch)
+    set_device_model!(template_uc, PowerLoad, StaticPowerLoad)
+    set_device_model!(template_uc, DeviceModel(Line, StaticBranch))
+    set_device_model!(
+        template_uc,
+        DeviceModel(TwoTerminalGenericHVDCLine, HVDCTwoTerminalLossless),
+    )
+
+    model = DecisionModel(template_uc, sys; name = "UC", optimizer = HiGHS_optimizer)
+    @test build!(model; output_dir = mktempdir()) == PSI.ModelBuildStatus.BUILT
+    @test solve!(model) == PSI.RunStatus.SUCCESSFULLY_FINALIZED
+
+    results = OptimizationProblemResults(model)
+    vd = read_variables(results)
+    data = PSI.get_power_flow_data(
+        only(PSI.get_power_flow_evaluation_data(PSI.get_optimization_container(model))),
+    )
+    base_power = get_base_power(sys)
+    bus_lookup = PFS.get_bus_lookup(data)
+
+    # Lossless formulation exposes a single flow variable wired to both terminals.
+    flow = vd["FlowActivePowerVariable__TwoTerminalGenericHVDCLine"][:, :value]
+    from_inj = data.bus_hvdc_net_power[bus_lookup[get_number(from)], :] * base_power
+    to_inj = data.bus_hvdc_net_power[bus_lookup[get_number(to)], :] * base_power
+
+    # The test is only meaningful if the line actually carries power.
+    @test maximum(abs, flow) > 1e-3
+    # from bus exports the flow (-F), to bus receives it (+F)...
+    @test isapprox(from_inj, -1 .* flow; atol = 1e-9, rtol = 0)
+    @test isapprox(to_inj, flow; atol = 1e-9, rtol = 0)
+    # ...so a lossless line nets to zero across its two terminals (the bug gave -2F).
+    @test isapprox(from_inj .+ to_inj, zeros(length(flow)); atol = 1e-9, rtol = 0)
+    # And the HVDC must not leak into bus_active_power_injections.
+    @test all(iszero, data.bus_active_power_injections[bus_lookup[get_number(from)], :])
+    @test all(iszero, data.bus_active_power_injections[bus_lookup[get_number(to)], :])
 end
 
 @testset "Test AC power flow in the loop: small system UCED, PSS/E export" for calculate_loss_factors in


### PR DESCRIPTION
## Problem

When an AC `power_flow_evaluation` runs in the loop on a model containing an `HVDCTwoTerminalLossless` line, the post-solve branch flows diverged sharply from the optimization's own flow variables (observed >1000 MW errors concentrated on inter-area tie lines).

## Cause

`HVDCTwoTerminalLossless` exposes a **single** `FlowActivePowerVariable`, wired to both the `pst_from_to` and `pst_to_from` categories. The pf-data writer subtracted that one variable at **both** terminals (`-F` at the from bus and `-F` at the to bus) instead of `-F / +F`. This injected a large same-sign phantom term (`≈ -2F`) that the AC power flow slack then had to absorb, flooding the lines near the slack. (The `HVDCTwoTerminalDispatch` model was correct, because its two loss-coupled variables `ft + tf = losses` are independently signed.)

## Fix

- Route HVDC terminal injections into `bus_hvdc_net_power` (mirroring how PowerFlows accumulates native HVDC setpoints) instead of `bus_active_power_injections`.
- Thread the variable (entry) type into `_update_pf_data_component!` so the to-bus sign is formulation-aware: `+= value` for the lossless single `FlowActivePowerVariable`, `-= value` for the dispatch `FlowActivePowerToFromVariable`. From-bus and PST handling unchanged.

Routing into `bus_hvdc_net_power` relies on `clear_injection_data!` zeroing that field each solve (Sienna-Platform/PowerFlows.jl#395).

## Tests

- Updated the existing dispatch in-the-loop test to read `bus_hvdc_net_power` and assert no leak into `bus_active_power_injections`.
- Added a lossless regression test (RTS, single flow variable) asserting `-F` / `+F` terminals that net to zero.

## Verification

On a UC(PTDF)→ED(AC OPF) RTS simulation with an HVDC line, max |ACOPF flow − post-solve PF flow| dropped from **1275.6 MW → 3.03 MW** (residual is genuine AC reconciliation), and the net injection handed to the slack dropped from 27.3 pu to 2.57 pu (system losses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)