### PR TITLE
Fix reductions with AreaInterchange and mixed parallel branches

### DIFF
--- a/src/core/network_model.jl
+++ b/src/core/network_model.jl
@@ -407,6 +407,11 @@ function _add_outage_monitored_irreducible_buses!(
     return
 end
 
+function _push_component_buses!(buses::Set{Int64}, branch::PSY.AreaInterchange)
+    # AreaInterchange is area-to-area and not bus-to-bus
+    return
+end
+
 function _push_component_buses!(buses::Set{Int64}, branch::PSY.Branch)
     arc = PSY.get_arc(branch)
     push!(buses, PSY.get_number(PSY.get_from(arc)))

--- a/src/devices_models/device_constructors/branch_constructor.jl
+++ b/src/devices_models/device_constructors/branch_constructor.jl
@@ -1515,7 +1515,7 @@ function _get_branch_map(network_model::NetworkModel)
                     (PSY.get_name(area_from), PSY.get_name(area_to)),
                     Dict{DataType, Vector{String}}(),
                 )
-                _add_to_branch_map!(branch_typed_dict, reduction_entry, name)
+                _add_to_branch_map!(branch_typed_dict, br_type, name)
             end
         end
     end
@@ -1536,10 +1536,14 @@ end
 
 function _add_to_branch_map!(
     branch_typed_dict::Dict{DataType, Vector{String}},
-    reduction_entry::Union{PNM.BranchesParallel, PNM.BranchesSeries},
+    branch_type::DataType,
     name::String,
 )
-    _add_to_branch_map!(branch_typed_dict, first(reduction_entry), name)
+    if !haskey(branch_typed_dict, branch_type)
+        branch_typed_dict[branch_type] = [name]
+    else
+        push!(branch_typed_dict[branch_type], name)
+    end
 end
 
 # This method uses ACBranch to support 2T - HVDC
@@ -1568,6 +1572,10 @@ function _get_area_from_to(reduction_entry::PNM.ThreeWindingTransformerWinding)
 end
 
 function _get_area_from_to(reduction_entry::PNM.BranchesParallel)
+    return _get_area_from_to(first(reduction_entry))
+end
+
+function _get_area_from_to(reduction_entry::PNM.AbstractBranchesParallel)
     return _get_area_from_to(first(reduction_entry))
 end
 


### PR DESCRIPTION
This PR addresses the following two errors:

**Error 1**:
```bash
MethodError: no method matching get_arc(::PowerSystems.AreaInterchange)
```
AreaInterchange is now skipped when collecting component buses for the reductions since it is area-area and has no arc.

**Error 2**:
```bash
MethodError: no method matching get_arc(::PowerNetworkMatrices.MixedBranchesParallel)
The function `get_arc` exists, but no method is defined for this combination of argument types.
```
PNM returns mixed parallel branch groups as `MixedBranchesParallel <: AbstractBranchesParallel`, while PSI was handling `BranchesParallel` only. Mixed parallel branch reductions are now handled consistently with existing parallel branch reductions.

**More details:**:
The errors appreared when running EI with `AreaPTDFPowerModel`, `AreaInterchange, Line, MonitoredLine => StaticBranch` and `reduce_degree_two_branches = true` (`reduce_radial_branches` is irrelevant for these errors) but I have reproduced the exact error using a modified version of RTS, using the following script: 
<details>
  <summary>Script</summary>

```julia
using Dates
using Logging
using PowerSystemCaseBuilder
const PSB = PowerSystemCaseBuilder
using PowerSystems
const PSY = PowerSystems
using PowerSimulations
const PSI = PowerSimulations
using PowerNetworkMatrices
const PNM = PowerNetworkMatrices
using HydroPowerSimulations

function add_area_interchanges!(sys)
    PSY.add_components!(
        sys,
        [
            PSY.AreaInterchange(;
                name = "interchange1_2",
                available = true,
                active_power_flow = 100.0,
                flow_limits = (from_to = 1.0, to_from = 1.0),
                from_area = PSY.get_component(PSY.Area, sys, "1"),
                to_area = PSY.get_component(PSY.Area, sys, "2"),
            ),
            PSY.AreaInterchange(;
                name = "interchange1_3",
                available = true,
                active_power_flow = 100.0,
                flow_limits = (from_to = 1.0, to_from = 1.0),
                from_area = PSY.get_component(PSY.Area, sys, "1"),
                to_area = PSY.get_component(PSY.Area, sys, "3"),
            ),
            PSY.AreaInterchange(;
                name = "interchange3_2",
                available = true,
                active_power_flow = 100.0,
                flow_limits = (from_to = 1.0, to_from = 1.0),
                from_area = PSY.get_component(PSY.Area, sys, "3"),
                to_area = PSY.get_component(PSY.Area, sys, "2"),
            ),
        ],
    )
end

function add_monitored_parallel_line!(sys; source_line_name = "A33-1")
    line = PSY.get_component(PSY.Line, sys, source_line_name)
    isnothing(line) && error("Could not find Line named $source_line_name")

    monitored_line = PSY.MonitoredLine(;
        name = "$(source_line_name)_monitored_parallel",
        available = PSY.get_available(line),
        active_power_flow = PSY.get_active_power_flow(line),
        reactive_power_flow = PSY.get_reactive_power_flow(line),
        arc = PSY.get_arc(line),
        r = PSY.get_r(line),
        x = PSY.get_x(line),
        b = PSY.get_b(line),
        flow_limits = (from_to = PSY.get_rating(line), to_from = PSY.get_rating(line)),
        rating = PSY.get_rating(line),
        angle_limits = PSY.get_angle_limits(line),
        rating_b = PSY.get_rating_b(line),
        rating_c = PSY.get_rating_c(line),
        g = PSY.get_g(line),
        services = PSY.Device[],
    )
    PSY.add_component!(sys, monitored_line)
    return monitored_line
end

function build_template(sys)
    ptdf = PNM.VirtualPTDF(
        sys;
        tol = 1e-3,
        max_cache_size = 10000,
        network_reductions = PNM.NetworkReduction[PNM.DegreeTwoReduction()],
    )

    template = PSI.ProblemTemplate(
        PSI.NetworkModel(
            PSI.AreaPTDFPowerModel;
            use_slacks = true,
            PTDF_matrix = ptdf,
            reduce_radial_branches = false,
            reduce_degree_two_branches = true,
        ),
    )

    PSI.set_device_model!(template, PSY.ThermalStandard, ThermalDispatchNoMin)
    PSI.set_device_model!(template, PSY.RenewableDispatch, RenewableFullDispatch)
    PSI.set_device_model!(template, PSY.PowerLoad, StaticPowerLoad)
    PSI.set_device_model!(template, PSY.RenewableNonDispatch, FixedOutput)
    PSI.set_device_model!(template, PSY.HydroDispatch, HydroDispatchRunOfRiver)
    PSI.set_device_model!(template, PSY.Line, StaticBranch)
    PSI.set_device_model!(
        template,
        PSI.DeviceModel(PSY.MonitoredLine, StaticBranch; use_slacks = false),
    )
    PSI.set_device_model!(template, PSY.AreaInterchange, StaticBranch)
    return template
end

function main()
    sys = PSB.build_system(PSB.PSISystems, "modified_RTS_GMLC_DA_sys")
    PSY.transform_single_time_series!(sys, Dates.Hour(24), Dates.Hour(1))
    add_area_interchanges!(sys)
    add_monitored_parallel_line!(sys)

    model = PSI.DecisionModel(
        build_template(sys),
        sys;
        name = "RTS_AreaPTDF_MixedParallel_DegreeTwo",
        resolution = Dates.Hour(1),
        initialize_model = false,
        optimizer_solve_log_print = true,
        rebuild_model = false,
        store_variable_names = true,
    )

    result = PSI.build!(
        model;
        output_dir = joinpath(@__DIR__, "results"),
        console_level = Logging.Info,
    )
    @info "build status" result
    result == PSI.ModelBuildStatus.BUILT || error("DecisionModel build failed: $(result)")
end

main()
```
</details>