### PR TITLE
Fix show(::OptimizationProblemResults) for single-period results

### DIFF
--- a/src/utils/print_pt_v2.jl
+++ b/src/utils/print_pt_v2.jl
@@ -505,17 +505,21 @@ function _show_method(
 ) where {T <: ProblemResultsTypes}
     timestamps = get_timestamps(results)
 
+    # `get_resolution` returns `nothing` when there is a single timestamp (no
+    # interval to diff), so guard against `Dates.Minute(nothing)`.
+    resolution = ISOPT.get_resolution(results)
+    resolution_str =
+        isnothing(resolution) ? "N/A (single period)" :
+        string(Dates.Minute(resolution))
+
     if backend == :html
         println(io, "<p> Start: $(first(timestamps))</p>")
         println(io, "<p> End: $(last(timestamps))</p>")
-        println(
-            io,
-            "<p> Resolution: $(Dates.Minute(ISOPT.get_resolution(results)))</p>",
-        )
+        println(io, "<p> Resolution: $(resolution_str)</p>")
     else
         println(io, "Start: $(first(timestamps))")
         println(io, "End: $(last(timestamps))")
-        println(io, "Resolution: $(Dates.Minute(ISOPT.get_resolution(results)))")
+        println(io, "Resolution: $(resolution_str)")
     end
 
     values = Dict{String, Vector{String}}(

--- a/src/utils/print_pt_v3.jl
+++ b/src/utils/print_pt_v3.jl
@@ -514,17 +514,21 @@ function _show_method(
 ) where {T <: ProblemResultsTypes}
     timestamps = get_timestamps(results)
 
+    # `get_resolution` returns `nothing` when there is a single timestamp (no
+    # interval to diff), so guard against `Dates.Minute(nothing)`.
+    resolution = ISOPT.get_resolution(results)
+    resolution_str =
+        isnothing(resolution) ? "N/A (single period)" :
+        string(Dates.Minute(resolution))
+
     if backend == :html
         println(io, "<p> Start: $(first(timestamps))</p>")
         println(io, "<p> End: $(last(timestamps))</p>")
-        println(
-            io,
-            "<p> Resolution: $(Dates.Minute(ISOPT.get_resolution(results)))</p>",
-        )
+        println(io, "<p> Resolution: $(resolution_str)</p>")
     else
         println(io, "Start: $(first(timestamps))")
         println(io, "End: $(last(timestamps))")
-        println(io, "Resolution: $(Dates.Minute(ISOPT.get_resolution(results)))")
+        println(io, "Resolution: $(resolution_str)")
     end
 
     values = Dict{String, Vector{String}}(

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -40,6 +40,24 @@ end
 
     _test_plain_print_methods(list)
     _test_html_print_methods(list)
+
+    # Regression: showing results with a single time period used to throw
+    # `MethodError: no method matching Minute(::Nothing)` because the
+    # resolution is `nothing` when there is only one timestamp.
+    dm_model_single = DecisionModel(
+        template,
+        c_sys5;
+        optimizer = HiGHS_optimizer,
+        horizon = Dates.Hour(1),
+    )
+    @test build!(dm_model_single; output_dir = mktempdir(; cleanup = true)) ==
+          PSI.ModelBuildStatus.BUILT
+    @test solve!(dm_model_single; optimizer = HiGHS_optimizer) ==
+          PSI.RunStatus.SUCCESSFULLY_FINALIZED
+    results_single = OptimizationProblemResults(dm_model_single)
+    @test length(get_timestamps(results_single)) == 1
+    output = sprint(show, "text/plain", results_single)
+    @test occursin("Resolution: N/A (single period)", output)
 end
 
 @testset "Test Simulation Print Methods" begin


### PR DESCRIPTION
## Problem
Printing an `OptimizationProblemResults`/`SimulationProblemResults` (`Union` aliased locally as `ProblemResultsTypes`) for a model with a single time period throws:

```
ERROR: MethodError: no method matching Minute(::Nothing)
```

`_show_method` (in both `src/utils/print_pt_v2.jl` and `src/utils/print_pt_v3.jl`) blindly wraps `ISOPT.get_resolution(results)` in `Dates.Minute(...)`, but `get_resolution` derives the resolution by diffing the timestamps and returns `nothing` when there's only one timestamp (nothing to diff).

## Fix
Compute the resolution string once in `_show_method`, guarding the `nothing` case (prints `N/A (single period)`), and reuse it in both the `:html` and `:plain` branches. Fixed in both `print_pt_v2.jl` and `print_pt_v3.jl` (conditionally included depending on the installed PrettyTables version).

## Test
Adds a regression test in `test/test_print.jl`: builds and solves a `DecisionModel` with `horizon = Dates.Hour(1)` (single timestep at the c_sys5 hourly resolution), then asserts `show` no longer throws and emits the `N/A (single period)` fallback string.

Verified locally: `Test Model Print Methods` (16/16) and `Test Simulation Print Methods` (14/14) pass.

Ports the fix and regression test from Sienna-Platform/InfrastructureOptimizationModels.jl#126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)