### PR TITLE
Give MBC test fixture's thermal unit a base power != system base

### DIFF
--- a/test/test_utils/mbc_system_utils.jl
+++ b/test/test_utils/mbc_system_utils.jl
@@ -292,6 +292,18 @@ function load_sys_incr()
             ),
         ),
     )[1] *= 0.9
+    # Give Test Unit1 a device base_power != system base_power, so unit-conversion bugs
+    # (e.g. rating-dependent per-unit multipliers) aren't masked by the two coinciding.
+    unit1 = get_component(SEL_INCR, sys)
+    with_units_base(sys, UnitSystem.NATURAL_UNITS) do
+        limits = get_active_power_limits(unit1)
+        rating = get_rating(unit1)
+        active_power = get_active_power(unit1)
+        set_base_power!(unit1, get_base_power(sys) * 1.4)
+        set_active_power_limits!(unit1, limits)
+        set_rating!(unit1, rating)
+        set_active_power!(unit1, active_power)
+    end
     return sys
 end
 


### PR DESCRIPTION
## Summary
- `load_sys_incr()`'s "Test Unit1" had device `base_power == get_base_power(sys)` (both 100 MVA). Any per-unit multiplier bug that only shows up when a component's rating differs from system base power was invisible to every test built on this shared fixture, including the thermal/hydro `MarketBidCost` agreement test in both this repo and `HydroPowerSimulations.jl`.
- Concretely, this masked [Sienna-Platform/HydroPowerSimulations.jl#136](https://github.com/Sienna-Platform/HydroPowerSimulations.jl/pull/136): `HydroGen`'s offer-curve breakpoint multiplier used `get_max_active_power(d)` instead of the `1.0` every other device type uses, and the thermal/hydro-agree test couldn't catch it because the two bases coincided.
- Sets Test Unit1's base power to `1.4x` system base, preserving its natural-units (MW) rating/limits/dispatch via `with_units_base(sys, NATURAL_UNITS)`.

## Test plan
- [x] Rebuilt `load_sys_incr()` standalone and confirmed `unit1.base_power` (140.0) now differs from `get_base_power(sys)` (100.0)
- [x] `test/test_market_bid_cost.jl` (full suite, not run here)