### PR TITLE
Fail the join of a partitioned simulation if any partition failed

### DIFF
--- a/docs/src/how_to/parallel_simulations.md
+++ b/docs/src/how_to/parallel_simulations.md
@@ -81,10 +81,10 @@ julia> run_parallel_simulation(
     )
 ```
 
-The final results will be in `./my_simulation_otuput/my_simulation`
+The final results will be in `./my_simulation_output/my_simulation`
 
 Note the log files and results for each partition are located in
-`./my_simulation_otuput/my_simulation/simulation_partitions`
+`./my_simulation_output/my_simulation/simulation_partitions`
 
 ### Failed partitions
 

--- a/docs/src/how_to/parallel_simulations.md
+++ b/docs/src/how_to/parallel_simulations.md
@@ -86,6 +86,22 @@ The final results will be in `./my_simulation_otuput/my_simulation`
 Note the log files and results for each partition are located in
 `./my_simulation_otuput/my_simulation/simulation_partitions`
 
+### Failed partitions
+
+If any partition fails, the join step throws an exception and records a failed status in
+`./my_simulation_output/my_simulation/results/status.json`. Each failed partition, along
+with the simulation steps that it covers, is logged in
+`./my_simulation_output/my_simulation/logs/join_partitioned_simulation.log`.
+
+If you want to inspect the results of the successful partitions, join them by skipping the
+failed partitions, as shown below. The status of the simulation remains a failure and the
+results of the steps that were covered by the failed partitions are invalid.
+
+```
+julia> PowerSimulations.join_simulation("my_simulation_output/my_simulation"; skip_failures=true)
+julia> results = SimulationResults("my_simulation_output/my_simulation"; ignore_status=true)
+```
+
 ## Run a Simulation in Parallel on an HPC
 
 This page describes how to split a simulation into partitions, run each partition in parallel
@@ -282,3 +298,15 @@ julia> results = SimulationResults("<output-dir>/job-outputs/<simulation-name>")
 
 Note the log files and results for each partition are located in
 `<output-dir>/job-outputs/<simulation-name>/simulation_partitions`
+
+If any partition fails, the join command fails and records a failed status in
+`<output-dir>/job-outputs/<simulation-name>/results/status.json`. Each failed partition,
+along with the simulation steps that it covers, is logged in
+`<output-dir>/job-outputs/<simulation-name>/logs/join_partitioned_simulation.log`.
+Re-run the command with the `--skip-failures` option to skip the failed partitions and merge
+the results of the successful ones. The status of the simulation remains a failure, so the
+results must be loaded with `SimulationResults(path; ignore_status=true)`.
+
+```
+$ julia --project=<path> my_simulation.jl join --simulation-name=<simulation-name> --output-dir=<output-dir>/job-outputs --skip-failures
+```

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -1198,13 +1198,33 @@ function serialize_status(sim::Simulation)
     serialize_status(get_simulation_status(sim), get_results_dir(sim))
 end
 
+_status_file_path(results_dir::AbstractString) = joinpath(results_dir, "status.json")
+
 function serialize_status(status::RunStatus, results_dir::AbstractString)
     data = Dict("run_status" => string(status))
-    filename = joinpath(results_dir, "status.json")
-    open(filename, "w") do io
+    open(_status_file_path(results_dir), "w") do io
         JSON3.write(io, data)
     end
 
+    return
+end
+
+"""
+Record RunStatus.FAILED in `results_dir` without throwing. Failure paths call this from
+catch blocks so that an IO error while recording the status cannot mask the exception
+that caused the failure.
+"""
+function _try_serialize_failed_status(results_dir::AbstractString)
+    try
+        # The directory may not exist if the failure occurred before the simulation
+        # created its output directories.
+        mkpath(results_dir)
+        serialize_status(RunStatus.FAILED, results_dir)
+    catch e
+        e isa InterruptException && rethrow()
+        @error "Failed to record RunStatus.FAILED" results_dir exception =
+            (e, catch_backtrace())
+    end
     return
 end
 
@@ -1213,7 +1233,7 @@ function deserialize_status(sim::Simulation)
 end
 
 function deserialize_status(results_path::AbstractString)
-    filename = joinpath(results_path, "status.json")
+    filename = _status_file_path(results_path)
     if !isfile(filename)
         error("run status file $filename does not exist")
     end

--- a/src/simulation/simulation_partition_results.jl
+++ b/src/simulation/simulation_partition_results.jl
@@ -29,19 +29,49 @@ function SimulationPartitionResults(path::AbstractString)
 end
 
 """
-Combine all partition simulation files.
+Combine all partition simulation files and return the status of the joined simulation.
+
+Throw an exception if any partition job failed, unless `skip_failures` is `true`.
+
+# Arguments
+
+  - `path::AbstractString`: Directory of the main simulation.
+  - `skip_failures::Bool`: If `true`, log and skip the store files of the partition jobs
+    that failed and merge the results of the successful jobs. The status of the joined
+    simulation is `RunStatus.FAILED` whenever any partition job failed, regardless of this
+    setting.
 """
-function join_simulation(path::AbstractString)
+function join_simulation(path::AbstractString; skip_failures = false)
     results = SimulationPartitionResults(path)
-    join_simulation(results)
-    return
+    return join_simulation(results; skip_failures = skip_failures)
 end
 
-function join_simulation(results::SimulationPartitionResults)
-    status = _check_jobs(results)
-    _merge_store_files!(results)
+function join_simulation(results::SimulationPartitionResults; skip_failures = false)
+    failed_partitions = _check_jobs(results)
+    if !isempty(failed_partitions) && !skip_failures
+        _serialize_failed_status(results)
+        error(
+            "These partition jobs were not successful: $(first.(failed_partitions)). " *
+            "Refer to the log messages above for the affected simulation steps. " *
+            "Pass skip_failures = true (--skip-failures on the command line) to skip the " *
+            "failed jobs and merge the results of the successful jobs.",
+        )
+    end
+
+    not_merged = try
+        _merge_store_files!(results, Set{Int}(first.(failed_partitions)), skip_failures)
+    catch
+        _serialize_failed_status(results)
+        rethrow()
+    end
+
+    status = if isempty(not_merged)
+        RunStatus.SUCCESSFULLY_FINALIZED
+    else
+        RunStatus.FAILED
+    end
     _complete(results, status)
-    return
+    return status
 end
 
 function _partition_path(x::SimulationPartitionResults, i)
@@ -58,39 +88,103 @@ end
 _store_subpath() = joinpath("data_store", "simulation_store.h5")
 _store_path(x::SimulationPartitionResults) = joinpath(x.path, _store_subpath())
 
-function _check_jobs(results::SimulationPartitionResults)
-    overall_status = RunStatus.SUCCESSFULLY_FINALIZED
-    for i in 1:get_num_partitions(results.partitions)
-        job_results_path = joinpath(_partition_path(results, 1), "results")
-        status = deserialize_status(job_results_path)
-        if status != RunStatus.SUCCESSFULLY_FINALIZED
-            @warn "partition job index = $i was not successful: $status"
-            overall_status = status
-        end
-    end
-
-    return overall_status
+"""
+Return the absolute range of simulation steps that the partition with the given index
+contributes to the merged store (excludes overlap steps).
+"""
+function _valid_step_range(x::SimulationPartitionResults, index::Int)
+    step_range = get_absolute_step_range(x.partitions, index)
+    first_step = step_range[get_valid_step_offset(x.partitions, index)]
+    return first_step:(first_step + get_valid_step_length(x.partitions, index) - 1)
 end
 
-function _merge_store_files!(results::SimulationPartitionResults)
-    HDF5.h5open(_store_path(results), "r+") do dst
-        for i in 1:get_num_partitions(results.partitions)
-            HDF5.h5open(joinpath(_partition_path(results, i), _store_subpath()), "r") do src
-                _copy_datasets!(results, i, src, dst)
-            end
+"""
+Return the indexes and statuses of the partition jobs that were not successful. Log an
+error message for each one of them.
+"""
+function _check_jobs(results::SimulationPartitionResults)
+    failed_jobs = Vector{Tuple{Int, RunStatus}}()
+    for i in 1:get_num_partitions(results.partitions)
+        status = try
+            deserialize_status(joinpath(_partition_path(results, i), RESULTS_DIR))
+        catch e
+            @error "Failed to read the status of partition job index = $i" exception =
+                (e, catch_backtrace())
+            RunStatus.FAILED
         end
-
-        for dataset in values(results.datasets)
-            if occursin("decision_models", HDF5.name(dataset))
-                IS.@assert_op HDF5.attrs(dataset)[_TEMP_WRITE_POSITION] ==
-                              size(dataset)[end] + 1
-            else
-                IS.@assert_op HDF5.attrs(dataset)[_TEMP_WRITE_POSITION] ==
-                              size(dataset)[1] + 1
-            end
-            delete!(HDF5.attrs(dataset), _TEMP_WRITE_POSITION)
+        if status != RunStatus.SUCCESSFULLY_FINALIZED
+            @error "Partition job index = $i was not successful: status = $status. " *
+                   "Results for steps = $(_valid_step_range(results, i)) will be invalid " *
+                   "in the merged store."
+            push!(failed_jobs, (i, status))
         end
     end
+
+    return failed_jobs
+end
+
+"""
+Merge the store files of all partitions into the main store file and return the indexes of
+the partitions that were not merged.
+
+Partitions in `skip_indexes` are never merged. If `skip_failures` is `true`, log and skip
+the partitions whose store files cannot be read; otherwise, propagate the exception.
+"""
+function _merge_store_files!(
+    results::SimulationPartitionResults,
+    skip_indexes::Set{Int},
+    skip_failures::Bool,
+)
+    not_merged = Int[]
+    HDF5.h5open(_store_path(results), "r+") do dst
+        try
+            for i in 1:get_num_partitions(results.partitions)
+                if i in skip_indexes
+                    @warn "Skip the store file of the failed partition job index = $i. " *
+                          "Results for steps = $(_valid_step_range(results, i)) will be " *
+                          "invalid in the merged store."
+                    push!(not_merged, i)
+                    continue
+                end
+                try
+                    HDF5.h5open(
+                        joinpath(_partition_path(results, i), _store_subpath()),
+                        "r",
+                    ) do src
+                        _copy_datasets!(results, i, src, dst)
+                    end
+                catch e
+                    (!skip_failures || e isa InterruptException) && rethrow()
+                    push!(not_merged, i)
+                    @error "Failed to merge the store file of partition job index = $i. " *
+                           "The file is missing or corrupted. Results for " *
+                           "steps = $(_valid_step_range(results, i)) will be invalid in " *
+                           "the merged store." exception = (e, catch_backtrace())
+                end
+            end
+
+            if isempty(not_merged)
+                for dataset in values(results.datasets)
+                    if occursin("decision_models", HDF5.name(dataset))
+                        IS.@assert_op HDF5.attrs(dataset)[_TEMP_WRITE_POSITION] ==
+                                      size(dataset)[end] + 1
+                    else
+                        IS.@assert_op HDF5.attrs(dataset)[_TEMP_WRITE_POSITION] ==
+                                      size(dataset)[1] + 1
+                    end
+                end
+            end
+        finally
+            # This runs on the error path as well, where the attribute may not be set for
+            # every cached dataset. Deleting a missing attribute would mask the exception.
+            for dataset in values(results.datasets)
+                if haskey(HDF5.attrs(dataset), _TEMP_WRITE_POSITION)
+                    delete!(HDF5.attrs(dataset), _TEMP_WRITE_POSITION)
+                end
+            end
+        end
+    end
+    return not_merged
 end
 
 function _copy_datasets!(
@@ -140,7 +234,10 @@ function _merge_dataset_columns!(results::SimulationPartitionResults, index, src
     src_end = src_start + len - 1
 
     IS.@assert_op ndims(src) == ndims(dst)
-    dst_start = HDF5.attrs(dst)[_TEMP_WRITE_POSITION]
+    # Compute the destination offset from the partition's absolute step range rather
+    # than from the running write position so that a skipped (corrupted) partition
+    # does not shift the data of subsequent partitions.
+    dst_start = (first(_valid_step_range(results, index)) - 1) * num_columns_per_step + 1
     if ndims(src) == 2
         IS.@assert_op size(src)[2] == size(dst)[2]
         dst_end = dst_start + len - 1
@@ -164,7 +261,8 @@ function _merge_dataset_rows!(results::SimulationPartitionResults, index, src, d
     src_end = src_start + len - 1
 
     IS.@assert_op ndims(src) == ndims(dst)
-    dst_start = HDF5.attrs(dst)[_TEMP_WRITE_POSITION]
+    # See the comment about the destination offset in _merge_dataset_columns!.
+    dst_start = (first(_valid_step_range(results, index)) - 1) * num_rows_per_step + 1
     if ndims(src) == 2
         IS.@assert_op size(src)[1] == size(dst)[1]
         dst_end = dst_start + len - 1
@@ -184,8 +282,17 @@ function _merge_dataset_rows!(results::SimulationPartitionResults, index, src, d
 end
 
 function _complete(results::SimulationPartitionResults, status)
-    serialize_status(status, joinpath(results.path, "results"))
+    serialize_status(status, joinpath(results.path, RESULTS_DIR))
     store_path = _store_path(results)
     IS.compute_file_hash(dirname(store_path), basename(store_path))
+    return
+end
+
+"""
+Record a failure in the status file of the joined simulation. Unlike [`_complete`](@ref),
+this does not compute the hash of the store file because the store was not merged.
+"""
+function _serialize_failed_status(results::SimulationPartitionResults)
+    serialize_status(RunStatus.FAILED, joinpath(results.path, RESULTS_DIR))
     return
 end

--- a/src/simulation/simulation_partition_results.jl
+++ b/src/simulation/simulation_partition_results.jl
@@ -1,4 +1,23 @@
-const _TEMP_WRITE_POSITION = "__write_position__"
+# Failure-handling contract for partitioned simulations (run_parallel_simulation and
+# join_simulation):
+#
+# 1. If any partition job fails, status.json of the joined simulation records
+#    RunStatus.FAILED.
+# 2. The exception that caused a failure always reaches the caller. Status recording and
+#    cleanup inside catch blocks are best-effort: guarded by one try/catch that logs and
+#    continues, and never allowed to replace the original exception.
+# 3. A missing partition status.json means that the partition job failed. Any other error
+#    while reading partition results (permissions, parse errors, wrong paths) indicates a
+#    problem with this process or environment and propagates instead of being reclassified
+#    as a partition failure. The one exception: with skip_failures = true, a partition
+#    store file that cannot be opened is skipped, because recovering from corrupted
+#    partition outputs is the purpose of that flag.
+# 4. InterruptException is a user action, not a failure: it propagates without recording
+#    RunStatus.FAILED.
+# 5. The datasets of a partition store must exactly match the merged store; a mismatch in
+#    either direction is an error.
+# 6. Failure paths are guarded exactly one level deep. If a guarded best-effort step
+#    itself fails, that is logged and otherwise out of scope.
 
 """
 Handles merging of simulation partitions
@@ -10,8 +29,6 @@ struct SimulationPartitionResults
     simulation_name::String
     "Defines how the simulation is split into partitions"
     partitions::SimulationPartitions
-    "Cache of datasets"
-    datasets::Dict{String, HDF5.Dataset}
 end
 
 function SimulationPartitionResults(path::AbstractString)
@@ -20,12 +37,7 @@ function SimulationPartitionResults(path::AbstractString)
         JSON3.read(io, Dict)
     end
     partitions = IS.deserialize(SimulationPartitions, config)
-    return SimulationPartitionResults(
-        path,
-        basename(path),
-        partitions,
-        Dict{String, HDF5.Dataset}(),
-    )
+    return SimulationPartitionResults(path, basename(path), partitions)
 end
 
 """
@@ -37,9 +49,9 @@ Throw an exception if any partition job failed, unless `skip_failures` is `true`
 
   - `path::AbstractString`: Directory of the main simulation.
   - `skip_failures::Bool`: If `true`, log and skip the store files of the partition jobs
-    that failed and merge the results of the successful jobs. The status of the joined
-    simulation is `RunStatus.FAILED` whenever any partition job failed, regardless of this
-    setting.
+    that failed or cannot be opened and merge the results of the successful jobs. The
+    status of the joined simulation is `RunStatus.FAILED` whenever any partition job
+    failed, regardless of this setting.
 """
 function join_simulation(path::AbstractString; skip_failures = false)
     results = SimulationPartitionResults(path)
@@ -49,9 +61,9 @@ end
 function join_simulation(results::SimulationPartitionResults; skip_failures = false)
     failed_partitions = _check_jobs(results)
     if !isempty(failed_partitions) && !skip_failures
-        _serialize_failed_status(results)
+        _try_serialize_failed_status(joinpath(results.path, RESULTS_DIR))
         error(
-            "These partition jobs were not successful: $(first.(failed_partitions)). " *
+            "These partition jobs were not successful: $failed_partitions. " *
             "Refer to the log messages above for the affected simulation steps. " *
             "Pass skip_failures = true (--skip-failures on the command line) to skip the " *
             "failed jobs and merge the results of the successful jobs.",
@@ -59,9 +71,18 @@ function join_simulation(results::SimulationPartitionResults; skip_failures = fa
     end
 
     not_merged = try
-        _merge_store_files!(results, Set{Int}(first.(failed_partitions)), skip_failures)
+        _merge_store_files!(results, Set(failed_partitions), skip_failures)
     catch
-        _serialize_failed_status(results)
+        # Best effort to keep the outputs usable: record the failure and, because the
+        # merge may have partially completed, recompute the store file hash so that
+        # SimulationResults(path; ignore_status = true) still works. Nothing here may
+        # mask the original exception.
+        try
+            _complete(results, RunStatus.FAILED)
+        catch cleanup_e
+            @error "Failed to finalize the results of the failed join" exception =
+                (cleanup_e, catch_backtrace())
+        end
         rethrow()
     end
 
@@ -99,24 +120,29 @@ function _valid_step_range(x::SimulationPartitionResults, index::Int)
 end
 
 """
-Return the indexes and statuses of the partition jobs that were not successful. Log an
-error message for each one of them.
+Return the indexes of the partition jobs that were not successful. Log an error message
+for each one of them.
 """
 function _check_jobs(results::SimulationPartitionResults)
-    failed_jobs = Vector{Tuple{Int, RunStatus}}()
+    failed_jobs = Int[]
     for i in 1:get_num_partitions(results.partitions)
-        status = try
-            deserialize_status(joinpath(_partition_path(results, i), RESULTS_DIR))
-        catch e
-            @error "Failed to read the status of partition job index = $i" exception =
-                (e, catch_backtrace())
-            RunStatus.FAILED
+        status_dir = joinpath(_partition_path(results, i), RESULTS_DIR)
+        # A missing status file means that the job died before recording its status. Any
+        # other error reading a status (permissions, parse errors) indicates a problem
+        # with this process or environment, not with the partition job, and propagates
+        # instead of marking the partition failed.
+        if isfile(_status_file_path(status_dir))
+            status = deserialize_status(status_dir)
+        else
+            @error "Partition job index = $i did not record a status; it may have died " *
+                   "before completing."
+            status = RunStatus.FAILED
         end
         if status != RunStatus.SUCCESSFULLY_FINALIZED
             @error "Partition job index = $i was not successful: status = $status. " *
                    "Results for steps = $(_valid_step_range(results, i)) will be invalid " *
                    "in the merged store."
-            push!(failed_jobs, (i, status))
+            push!(failed_jobs, i)
         end
     end
 
@@ -128,7 +154,8 @@ Merge the store files of all partitions into the main store file and return the 
 the partitions that were not merged.
 
 Partitions in `skip_indexes` are never merged. If `skip_failures` is `true`, log and skip
-the partitions whose store files cannot be read; otherwise, propagate the exception.
+the partitions whose store files cannot be opened; otherwise, propagate the exception.
+Errors raised after a store file has been opened always propagate.
 """
 function _merge_store_files!(
     results::SimulationPartitionResults,
@@ -137,50 +164,29 @@ function _merge_store_files!(
 )
     not_merged = Int[]
     HDF5.h5open(_store_path(results), "r+") do dst
-        try
-            for i in 1:get_num_partitions(results.partitions)
-                if i in skip_indexes
-                    @warn "Skip the store file of the failed partition job index = $i. " *
-                          "Results for steps = $(_valid_step_range(results, i)) will be " *
-                          "invalid in the merged store."
-                    push!(not_merged, i)
-                    continue
-                end
-                try
-                    HDF5.h5open(
-                        joinpath(_partition_path(results, i), _store_subpath()),
-                        "r",
-                    ) do src
-                        _copy_datasets!(results, i, src, dst)
-                    end
-                catch e
-                    (!skip_failures || e isa InterruptException) && rethrow()
-                    push!(not_merged, i)
-                    @error "Failed to merge the store file of partition job index = $i. " *
-                           "The file is missing or corrupted. Results for " *
-                           "steps = $(_valid_step_range(results, i)) will be invalid in " *
-                           "the merged store." exception = (e, catch_backtrace())
-                end
+        for i in 1:get_num_partitions(results.partitions)
+            if i in skip_indexes
+                @warn "Skip the store file of the failed partition job index = $i. " *
+                      "Results for steps = $(_valid_step_range(results, i)) will be " *
+                      "invalid in the merged store."
+                push!(not_merged, i)
+                continue
             end
-
-            if isempty(not_merged)
-                for dataset in values(results.datasets)
-                    if occursin("decision_models", HDF5.name(dataset))
-                        IS.@assert_op HDF5.attrs(dataset)[_TEMP_WRITE_POSITION] ==
-                                      size(dataset)[end] + 1
-                    else
-                        IS.@assert_op HDF5.attrs(dataset)[_TEMP_WRITE_POSITION] ==
-                                      size(dataset)[1] + 1
-                    end
-                end
+            src = try
+                HDF5.h5open(joinpath(_partition_path(results, i), _store_subpath()), "r")
+            catch e
+                (!skip_failures || e isa InterruptException) && rethrow()
+                push!(not_merged, i)
+                @error "Failed to open the store file of partition job index = $i. " *
+                       "The file is missing or corrupted. Results for " *
+                       "steps = $(_valid_step_range(results, i)) will be invalid in " *
+                       "the merged store." exception = (e, catch_backtrace())
+                continue
             end
-        finally
-            # This runs on the error path as well, where the attribute may not be set for
-            # every cached dataset. Deleting a missing attribute would mask the exception.
-            for dataset in values(results.datasets)
-                if haskey(HDF5.attrs(dataset), _TEMP_WRITE_POSITION)
-                    delete!(HDF5.attrs(dataset), _TEMP_WRITE_POSITION)
-                end
+            try
+                _copy_datasets!(results, i, src, dst)
+            finally
+                close(src)
             end
         end
     end
@@ -195,104 +201,112 @@ function _copy_datasets!(
 )
     output_types = string.(STORE_CONTAINERS)
 
-    function process_dataset(src_dataset, merge_func)
-        if !endswith(HDF5.name(src_dataset), "__columns")
-            name = HDF5.name(src_dataset)
-            dst_dataset = dst[name]
-            if !haskey(results.datasets, name)
-                results.datasets[name] = dst_dataset
-                HDF5.attrs(dst_dataset)[_TEMP_WRITE_POSITION] = 1
-            end
-            merge_func(results, index, src_dataset, dst_dataset)
+    # A dataset present in only one of the stores means that the partition was built
+    # differently than the main simulation; merging would silently produce incomplete
+    # results in one direction and leave a region of the destination unwritten in the
+    # other.
+    function check_matching_names(group_path)
+        src_names = sort!(keys(src[group_path]))
+        dst_names = sort!(keys(dst[group_path]))
+        if src_names != dst_names
+            error(
+                "The partition store and the merged store have different contents at " *
+                "$group_path: partition = $src_names, merged = $dst_names. The " *
+                "partition was likely built with different inputs than the main " *
+                "simulation.",
+            )
         end
     end
 
-    for src_group in src["simulation/decision_models"]
+    function process_dataset(dst_dataset, merge_func)
+        name = HDF5.name(dst_dataset)
+        if !endswith(name, "__columns")
+            merge_func(results, index, src[name], dst_dataset)
+        end
+    end
+
+    check_matching_names("simulation/decision_models")
+    for dst_group in dst["simulation/decision_models"]
+        group_name = HDF5.name(dst_group)
+        check_matching_names(group_name)
         for output_type in output_types
-            for src_dataset in src_group[output_type]
-                process_dataset(src_dataset, _merge_dataset_rows!)
+            check_matching_names("$group_name/$output_type")
+            for dst_dataset in dst_group[output_type]
+                process_dataset(dst_dataset, _merge_dataset_rows!)
             end
         end
-        process_dataset(src_group["optimizer_stats"], _merge_dataset_rows!)
+        process_dataset(dst_group["optimizer_stats"], _merge_dataset_rows!)
     end
 
     for output_type in output_types
-        for src_dataset in src["simulation/emulation_model/$output_type"]
-            process_dataset(src_dataset, _merge_dataset_columns!)
+        check_matching_names("simulation/emulation_model/$output_type")
+        for dst_dataset in dst["simulation/emulation_model/$output_type"]
+            process_dataset(dst_dataset, _merge_dataset_columns!)
         end
     end
 end
 
-function _merge_dataset_columns!(results::SimulationPartitionResults, index, src, dst)
-    num_columns = size(src)[1]
+"""
+Return the ranges of the source and destination datasets in the step dimension for merging
+the partition with the given index. `src_size` and `dst_size` are the sizes of the
+datasets in that dimension.
+"""
+function _merge_ranges(
+    results::SimulationPartitionResults,
+    index::Int,
+    src_size::Int,
+    dst_size::Int,
+)
     step_range = get_absolute_step_range(results.partitions, index)
-    IS.@assert_op num_columns % length(step_range) == 0
-    num_columns_per_step = num_columns ÷ length(step_range)
-    skip_offset = get_valid_step_offset(results.partitions, index) - 1
-    src_start = 1 + num_columns_per_step * skip_offset
-    len = get_valid_step_length(results.partitions, index) * num_columns_per_step
-    src_end = src_start + len - 1
-
-    IS.@assert_op ndims(src) == ndims(dst)
-    # Compute the destination offset from the partition's absolute step range rather
-    # than from the running write position so that a skipped (corrupted) partition
-    # does not shift the data of subsequent partitions.
-    dst_start = (first(_valid_step_range(results, index)) - 1) * num_columns_per_step + 1
-    if ndims(src) == 2
-        IS.@assert_op size(src)[2] == size(dst)[2]
-        dst_end = dst_start + len - 1
-        dst[dst_start:dst_end, :] = src[src_start:src_end, :]
-    else
-        error("Unsupported dataset ndims: $(ndims(src))")
-    end
-
-    HDF5.attrs(dst)[_TEMP_WRITE_POSITION] = dst_end + 1
-    return
+    IS.@assert_op src_size % length(step_range) == 0
+    per_step = src_size ÷ length(step_range)
+    # Guarantees that the absolute destination offsets computed below are in bounds and
+    # consistent across all partitions.
+    IS.@assert_op per_step * results.partitions.num_steps == dst_size
+    # Compute both offsets from the same absolute range of valid steps so that they
+    # cannot drift apart, and compute the destination offset from absolute steps rather
+    # than from a running write position so that a skipped (corrupted) partition does
+    # not shift the data of subsequent partitions.
+    valid_range = _valid_step_range(results, index)
+    len = length(valid_range) * per_step
+    src_start = 1 + per_step * (first(valid_range) - first(step_range))
+    dst_start = (first(valid_range) - 1) * per_step + 1
+    return (src_start:(src_start + len - 1), dst_start:(dst_start + len - 1))
 end
 
-function _merge_dataset_rows!(results::SimulationPartitionResults, index, src, dst)
-    num_rows = size(src)[end]
-    step_range = get_absolute_step_range(results.partitions, index)
-    IS.@assert_op num_rows % length(step_range) == 0
-    num_rows_per_step = num_rows ÷ length(step_range)
-    skip_offset = get_valid_step_offset(results.partitions, index) - 1
-    src_start = 1 + num_rows_per_step * skip_offset
-    len = get_valid_step_length(results.partitions, index) * num_rows_per_step
-    src_end = src_start + len - 1
+# Emulation model datasets grow along the first dimension; decision model datasets grow
+# along the last dimension.
+_merge_dataset_columns!(results::SimulationPartitionResults, index, src, dst) =
+    _merge_dataset!(results, index, src, dst, 1, (2,))
+_merge_dataset_rows!(results::SimulationPartitionResults, index, src, dst) =
+    _merge_dataset!(results, index, src, dst, ndims(dst), (2, 3))
 
+function _merge_dataset!(
+    results::SimulationPartitionResults,
+    index,
+    src,
+    dst,
+    step_dim::Int,
+    supported_ndims,
+)
     IS.@assert_op ndims(src) == ndims(dst)
-    # See the comment about the destination offset in _merge_dataset_columns!.
-    dst_start = (first(_valid_step_range(results, index)) - 1) * num_rows_per_step + 1
-    if ndims(src) == 2
-        IS.@assert_op size(src)[1] == size(dst)[1]
-        dst_end = dst_start + len - 1
-        dst[:, dst_start:dst_end] = src[:, src_start:src_end]
-    elseif ndims(src) == 3
-        IS.@assert_op size(src)[1] == size(dst)[1]
-        IS.@assert_op size(src)[2] == size(dst)[2]
-        dst_end = dst_start + len - 1
-        IS.@assert_op dst_end <= size(dst)[3]
-        dst[:, :, dst_start:dst_end] = src[:, :, src_start:src_end]
-    else
-        error("Unsupported dataset ndims: $(ndims(src))")
+    ndims(dst) in supported_ndims || error("Unsupported dataset ndims: $(ndims(dst))")
+    for dim in 1:ndims(dst)
+        dim == step_dim && continue
+        IS.@assert_op size(src)[dim] == size(dst)[dim]
     end
-
-    HDF5.attrs(dst)[_TEMP_WRITE_POSITION] = dst_end + 1
+    src_range, dst_range =
+        _merge_ranges(results, index, size(src)[step_dim], size(dst)[step_dim])
+    src_indexes = ntuple(d -> d == step_dim ? src_range : Colon(), ndims(dst))
+    dst_indexes = ntuple(d -> d == step_dim ? dst_range : Colon(), ndims(dst))
+    dst[dst_indexes...] = src[src_indexes...]
     return
 end
 
 function _complete(results::SimulationPartitionResults, status)
     serialize_status(status, joinpath(results.path, RESULTS_DIR))
     store_path = _store_path(results)
-    IS.compute_file_hash(dirname(store_path), basename(store_path))
-    return
-end
-
-"""
-Record a failure in the status file of the joined simulation. Unlike [`_complete`](@ref),
-this does not compute the hash of the store file because the store was not merged.
-"""
-function _serialize_failed_status(results::SimulationPartitionResults)
-    serialize_status(RunStatus.FAILED, joinpath(results.path, RESULTS_DIR))
+    # The store may not exist if the merge failed before it could be opened.
+    isfile(store_path) && IS.compute_file_hash(dirname(store_path), basename(store_path))
     return
 end

--- a/src/simulation/simulation_partitions.jl
+++ b/src/simulation/simulation_partitions.jl
@@ -84,6 +84,29 @@ function IS.serialize(partitions::SimulationPartitions)
     return IS.serialize_struct(partitions)
 end
 
+"""
+Run one operation of a partitioned simulation from command-line arguments.
+
+# Arguments
+
+  - `build_function`: Function reference that returns a built Simulation.
+  - `execute_function`: Function reference that executes a Simulation.
+  - `args`: Command-line arguments. The first one must be `setup`, `execute`, or `join`.
+    The rest must be options in the format `--name=value` or, for flags, `--name`.
+
+# Options
+
+  - `--output-dir=<path>`: Path for simulation outputs. Required for all operations unless
+    the environment variable `JADE_RUNTIME_OUTPUT` is set.
+  - `--simulation-name=<name>`: Simulation name. Required for all operations.
+  - `--num-steps=<n>`, `--num-period-steps=<n>`, `--num-overlap-steps=<n>`: Definition of
+    the partitions. Required by `setup`, except for `--num-overlap-steps`, which defaults
+    to 0.
+  - `--index=<n>`: Index of the partition to run. Required by `execute`.
+  - `--skip-failures`: Only applies to `join`. Skip the partition jobs that failed and merge
+    the results of the successful jobs. `join` fails if any partition job failed and this is
+    not set. The status of the joined simulation is a failure either way.
+"""
 function process_simulation_partition_cli_args(build_function, execute_function, args...)
     length(args) < 2 && error("Usage: setup|execute|join [options]")
     function config_logging(filename)
@@ -105,13 +128,26 @@ function process_simulation_partition_cli_args(build_function, execute_function,
         !isempty(diff) && error("Missing required options for $label: $diff")
     end
 
+    function get_bool_option(options, name)
+        value = lowercase(get(options, name, "false"))
+        value in ("true", "false") ||
+            error("The option --$name must be set to true or false: $value")
+        return parse(Bool, value)
+    end
+
     operation = args[1]
     options = Dict{String, String}()
     for opt in args[2:end]
         !startswith(opt, "--") && error("All options must start with '--': $opt")
         fields = split(opt[3:end], "=")
-        length(fields) != 2 && error("All options must use the format --name=value: $opt")
-        options[fields[1]] = fields[2]
+        if length(fields) == 1
+            # Flags, such as --skip-failures, don't require a value.
+            options[fields[1]] = "true"
+        elseif length(fields) == 2
+            options[fields[1]] = fields[2]
+        else
+            error("All options must use the format --name=value or --name: $opt")
+        end
     end
 
     if haskey(options, "output-dir")
@@ -162,7 +198,10 @@ function process_simulation_partition_cli_args(build_function, execute_function,
         end
         partitions = IS.deserialize(SimulationPartitions, config)
         config_logging(joinpath(base_dir, "logs", "join_partitioned_simulation.log"))
-        join_simulation(base_dir)
+        join_simulation(
+            base_dir;
+            skip_failures = get_bool_option(options, "skip-failures"),
+        )
     else
         error("Unsupported operation=$operation")
     end
@@ -172,6 +211,10 @@ end
 
 """
 Run a partitioned simulation in parallel on a local computer.
+
+Throw an exception if any partition fails. In that case the results of the successful
+partitions can still be merged by calling
+`PowerSimulations.join_simulation(joinpath(output_dir, name); skip_failures = true)`.
 
 # Arguments
 

--- a/src/simulation/simulation_partitions.jl
+++ b/src/simulation/simulation_partitions.jl
@@ -219,14 +219,12 @@ end
 Return `true` if the exception is an InterruptException, including one wrapped in the
 exception types that `Distributed.pmap` uses to propagate worker failures.
 """
-function _is_interrupt(e)
-    e isa InterruptException && return true
-    e isa Distributed.RemoteException && return _is_interrupt(e.captured.ex)
-    e isa CapturedException && return _is_interrupt(e.ex)
-    e isa TaskFailedException && return _is_interrupt(e.task.exception)
-    e isa CompositeException && return any(_is_interrupt, e.exceptions)
-    return false
-end
+_is_interrupt(::InterruptException) = true
+_is_interrupt(e::Distributed.RemoteException) = _is_interrupt(e.captured.ex)
+_is_interrupt(e::CapturedException) = _is_interrupt(e.ex)
+_is_interrupt(e::TaskFailedException) = _is_interrupt(e.task.result)
+_is_interrupt(e::CompositeException) = any(_is_interrupt, e.exceptions)
+_is_interrupt(_) = false
 
 """
 Run a partitioned simulation in parallel on a local computer.

--- a/src/simulation/simulation_partitions.jl
+++ b/src/simulation/simulation_partitions.jl
@@ -135,13 +135,16 @@ function process_simulation_partition_cli_args(build_function, execute_function,
         return parse(Bool, value)
     end
 
+    flag_options = ("skip-failures",)
     operation = args[1]
     options = Dict{String, String}()
     for opt in args[2:end]
         !startswith(opt, "--") && error("All options must start with '--': $opt")
         fields = split(opt[3:end], "=")
         if length(fields) == 1
-            # Flags, such as --skip-failures, don't require a value.
+            # Only flags, such as --skip-failures, don't require a value.
+            fields[1] in flag_options ||
+                error("The option --$(fields[1]) requires a value: --$(fields[1])=<value>")
             options[fields[1]] = "true"
         elseif length(fields) == 2
             options[fields[1]] = fields[2]
@@ -214,8 +217,9 @@ end
 """
 Run a partitioned simulation in parallel on a local computer.
 
-Throw an exception if any partition fails. In that case the results of the successful
-partitions can still be merged by calling
+Throw an exception if any partition fails. In that case a failed status is recorded in
+`<output_dir>/<name>/results/status.json` and the results of the successful partitions can
+still be merged by calling
 `PowerSimulations.join_simulation(joinpath(output_dir, name); skip_failures = true)`.
 
 # Arguments
@@ -297,14 +301,29 @@ function run_parallel_simulation(
     end
 
     Distributed.@everywhere include($script)
+    worker_exception = nothing
     try
         Distributed.pmap(PowerSimulations._run_parallel_simulation, jobs)
+    catch e
+        # Defer the exception so that the join step below still runs and records a
+        # failed status in the results directory.
+        worker_exception = (e, catch_backtrace())
+        @error "One or more partition jobs failed." exception = worker_exception
     finally
         Distributed.rmprocs(Distributed.workers()...)
     end
 
     args = ["join", "--simulation-name=$name", "--output-dir=$output_dir"]
-    process_simulation_partition_cli_args(build_function, execute_function, args...)
+    try
+        process_simulation_partition_cli_args(build_function, execute_function, args...)
+    catch e
+        isnothing(worker_exception) && rethrow()
+        # The original worker exception is the root cause; log the join error instead
+        # of letting it mask that exception.
+        @error "Failed to join the simulation results." exception = (e, catch_backtrace())
+    end
+    isnothing(worker_exception) || throw(worker_exception[1])
+    return
 end
 
 function _run_parallel_simulation(params)

--- a/src/simulation/simulation_partitions.jl
+++ b/src/simulation/simulation_partitions.jl
@@ -146,7 +146,9 @@ function process_simulation_partition_cli_args(build_function, execute_function,
         elseif length(fields) == 2
             options[fields[1]] = fields[2]
         else
-            error("All options must use the format --name=value or --name: $opt")
+            error(
+                "Invalid option: $opt. Options must use the format --name=value or --name",
+            )
         end
     end
 

--- a/src/simulation/simulation_partitions.jl
+++ b/src/simulation/simulation_partitions.jl
@@ -104,8 +104,9 @@ Run one operation of a partitioned simulation from command-line arguments.
     to 0.
   - `--index=<n>`: Index of the partition to run. Required by `execute`.
   - `--skip-failures`: Only applies to `join`. Skip the partition jobs that failed and merge
-    the results of the successful jobs. `join` fails if any partition job failed and this is
-    not set. The status of the joined simulation is a failure either way.
+    the results of the successful jobs. `join` raises an error if any partition job failed
+    either way; if this is set, the results of the successful jobs are merged first. The
+    status of the joined simulation is a failure either way.
 """
 function process_simulation_partition_cli_args(build_function, execute_function, args...)
     length(args) < 2 && error("Usage: setup|execute|join [options]")
@@ -140,18 +141,16 @@ function process_simulation_partition_cli_args(build_function, execute_function,
     options = Dict{String, String}()
     for opt in args[2:end]
         !startswith(opt, "--") && error("All options must start with '--': $opt")
-        fields = split(opt[3:end], "=")
+        # Only the first '=' separates the name from the value; the value may contain
+        # '=' characters (e.g. in a path).
+        fields = split(opt[3:end], "="; limit = 2)
         if length(fields) == 1
             # Only flags, such as --skip-failures, don't require a value.
             fields[1] in flag_options ||
                 error("The option --$(fields[1]) requires a value: --$(fields[1])=<value>")
             options[fields[1]] = "true"
-        elseif length(fields) == 2
-            options[fields[1]] = fields[2]
         else
-            error(
-                "Invalid option: $opt. Options must use the format --name=value or --name",
-            )
+            options[fields[1]] = fields[2]
         end
     end
 
@@ -197,21 +196,36 @@ function process_simulation_partition_cli_args(build_function, execute_function,
     elseif operation == "join"
         throw_if_missing(keys(options), Set(("simulation-name",)), operation)
         base_dir = joinpath(output_dir, options["simulation-name"])
-        config_file = joinpath(base_dir, "simulation_partitions", "config.json")
-        config = open(config_file, "r") do io
-            JSON3.read(io, Dict)
-        end
-        partitions = IS.deserialize(SimulationPartitions, config)
         config_logging(joinpath(base_dir, "logs", "join_partitioned_simulation.log"))
-        join_simulation(
+        status = join_simulation(
             base_dir;
             skip_failures = get_bool_option(options, "skip-failures"),
         )
+        if status != RunStatus.SUCCESSFULLY_FINALIZED
+            error(
+                "The results of the successful partition jobs were merged, but the " *
+                "status of the joined simulation is $status because one or more " *
+                "partition jobs failed.",
+            )
+        end
     else
         error("Unsupported operation=$operation")
     end
 
     return
+end
+
+"""
+Return `true` if the exception is an InterruptException, including one wrapped in the
+exception types that `Distributed.pmap` uses to propagate worker failures.
+"""
+function _is_interrupt(e)
+    e isa InterruptException && return true
+    e isa Distributed.RemoteException && return _is_interrupt(e.captured.ex)
+    e isa CapturedException && return _is_interrupt(e.ex)
+    e isa TaskFailedException && return _is_interrupt(e.task.exception)
+    e isa CompositeException && return any(_is_interrupt, e.exceptions)
+    return false
 end
 
 """
@@ -301,28 +315,24 @@ function run_parallel_simulation(
     end
 
     Distributed.@everywhere include($script)
-    worker_exception = nothing
     try
         Distributed.pmap(PowerSimulations._run_parallel_simulation, jobs)
     catch e
-        # Defer the exception so that the join step below still runs and records a
-        # failed status in the results directory.
-        worker_exception = (e, catch_backtrace())
-        @error "One or more partition jobs failed." exception = worker_exception
+        # Do not attempt the join; it would fail because at least one partition failed.
+        # Record the failure so that the results directory reports it — unless the user
+        # interrupted the run, which is not a simulation failure. The results of the
+        # successful partitions can still be merged with
+        # join_simulation(path; skip_failures = true).
+        if !_is_interrupt(e)
+            _try_serialize_failed_status(joinpath(output_dir, name, RESULTS_DIR))
+        end
+        rethrow()
     finally
         Distributed.rmprocs(Distributed.workers()...)
     end
 
     args = ["join", "--simulation-name=$name", "--output-dir=$output_dir"]
-    try
-        process_simulation_partition_cli_args(build_function, execute_function, args...)
-    catch e
-        isnothing(worker_exception) && rethrow()
-        # The original worker exception is the root cause; log the join error instead
-        # of letting it mask that exception.
-        @error "Failed to join the simulation results." exception = (e, catch_backtrace())
-    end
-    isnothing(worker_exception) || throw(worker_exception[1])
+    process_simulation_partition_cli_args(build_function, execute_function, args...)
     return
 end
 

--- a/test/test_simulation_partitions.jl
+++ b/test/test_simulation_partitions.jl
@@ -26,6 +26,25 @@
     @test_throws ErrorException PSI.get_absolute_step_range(partitions, 54)
 end
 
+@testset "Test interrupt detection" begin
+    remote = PSI.Distributed.RemoteException(
+        1,
+        CapturedException(InterruptException(), Any[]),
+    )
+    @test PSI._is_interrupt(InterruptException())
+    @test PSI._is_interrupt(remote)
+    @test PSI._is_interrupt(CompositeException([ErrorException("failed"), remote]))
+    @test !PSI._is_interrupt(ErrorException("failed"))
+    @test !PSI._is_interrupt(
+        CompositeException([
+            PSI.Distributed.RemoteException(
+                1,
+                CapturedException(ErrorException("failed"), Any[]),
+            ),
+        ]),
+    )
+end
+
 @testset "Test simulation partitions" begin
     sim_dir = mktempdir()
     script = joinpath(BASE_DIR, "test", "run_partitioned_simulation.jl")
@@ -176,10 +195,14 @@ end
         for (key, pre_df) in pre_variables
             post_df = post_variables[key]
             @test nrow(post_df) == nrow(pre_df)
-            @test nrow(pre_df) % num_partitions == 0
-            rows_per_step = nrow(pre_df) ÷ num_partitions
+            num_steps = partition_results.partitions.num_steps
+            @test nrow(pre_df) % num_steps == 0
+            rows_per_step = nrow(pre_df) ÷ num_steps
+            skipped_steps = PSI._valid_step_range(partition_results, failed_index)
             skipped_rows =
-                (rows_per_step * (failed_index - 1) + 1):(rows_per_step * failed_index)
+                (rows_per_step * (first(skipped_steps) - 1) + 1):(rows_per_step * last(
+                    skipped_steps,
+                ))
             merged_rows = setdiff(1:nrow(pre_df), skipped_rows)
             # The successful partitions must be merged at their original steps.
             @test post_df[merged_rows, :] == pre_df[merged_rows, :]
@@ -199,7 +222,9 @@ end
         cli_args...,
     )
     @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
-    PSI.process_simulation_partition_cli_args(
+    # The command must fail even with --skip-failures so that scripts detect the failure,
+    # but only after merging the results of the successful jobs.
+    @test_throws ErrorException PSI.process_simulation_partition_cli_args(
         build_simulation,
         execute_simulation,
         cli_args...,
@@ -207,10 +232,9 @@ end
     )
     @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
 
-    # Options must be rejected if they are malformed, have an invalid value, or are
-    # missing a required value.
-    for invalid_option in
-        ("--skip-failures=maybe", "--simulation-name=a=b", "--simulation-name")
+    # Options must be rejected if they have an invalid value or are missing a required
+    # value.
+    for invalid_option in ("--skip-failures=maybe", "--simulation-name")
         @test_throws ErrorException PSI.process_simulation_partition_cli_args(
             build_simulation,
             execute_simulation,
@@ -218,6 +242,24 @@ end
             invalid_option,
         )
     end
+
+    # Option values may contain '=': only the first '=' separates the name from the
+    # value. The parse succeeds and the failure comes from the nonexistent simulation
+    # named "a=b", not from option parsing.
+    parse_err = try
+        PSI.process_simulation_partition_cli_args(
+            build_simulation,
+            execute_simulation,
+            "join",
+            "--simulation-name=a=b",
+            "--output-dir=$sim_dir",
+        )
+        nothing
+    catch e
+        e
+    end
+    @test parse_err !== nothing
+    @test !occursin("Invalid option", sprint(showerror, parse_err))
 
     PSI.serialize_status(
         PSI.RunStatus.SUCCESSFULLY_FINALIZED,
@@ -244,7 +286,7 @@ end
         mv(store_backup, store_file; force = true)
     end
 
-    # A job whose status cannot be read must be treated as a failure.
+    # A job whose status file is missing must be treated as a failure.
     status_file = joinpath(partition_status_path(corrupted_index), "status.json")
     status_backup = status_file * ".backup"
     mv(status_file, status_backup)
@@ -252,7 +294,14 @@ end
         @test_throws ErrorException PSI.join_simulation(base_dir)
         @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
         @test PSI.join_simulation(base_dir; skip_failures = true) == PSI.RunStatus.FAILED
+        # A status file that exists but cannot be read indicates a problem with the
+        # environment rather than a failed partition job, and must propagate even with
+        # skip_failures = true.
+        write(status_file, "not JSON")
+        @test_throws Exception PSI.join_simulation(base_dir)
+        @test_throws Exception PSI.join_simulation(base_dir; skip_failures = true)
     finally
+        rm(status_file; force = true)
         mv(status_backup, status_file; force = true)
     end
 

--- a/test/test_simulation_partitions.jl
+++ b/test/test_simulation_partitions.jl
@@ -145,13 +145,77 @@ end
         end
     end
 
-    # TODO: Can emulation model results be validated?
-
-    # The checks below sabotage the partition outputs and so must be last.
     base_dir = joinpath(sim_dir, partition_name)
     partition_results = PSI.SimulationPartitionResults(base_dir)
-    joined_status_path = joinpath(base_dir, PSI.RESULTS_DIR)
     num_partitions = get_num_partitions(partition_results.partitions)
+
+    function compare_store_dataset(index, src_dataset, dst_dataset, step_dim)
+        step_range = PSI.get_absolute_step_range(partition_results.partitions, index)
+        per_step = size(src_dataset, step_dim) ÷ length(step_range)
+        valid_range = PSI._valid_step_range(partition_results, index)
+        len = length(valid_range) * per_step
+        src_start = 1 + per_step * (first(valid_range) - first(step_range))
+        dst_start = 1 + per_step * (first(valid_range) - 1)
+        src_range = src_start:(src_start + len - 1)
+        dst_range = dst_start:(dst_start + len - 1)
+        src_indexes = ntuple(d -> d == step_dim ? src_range : Colon(), ndims(src_dataset))
+        dst_indexes = ntuple(d -> d == step_dim ? dst_range : Colon(), ndims(dst_dataset))
+        @test isequal(dst_dataset[dst_indexes...], src_dataset[src_indexes...])
+    end
+
+    function compare_store_group(index, partition_store, merged_store, group_path, step_dim)
+        @test sort(collect(keys(partition_store[group_path]))) ==
+              sort(collect(keys(merged_store[group_path])))
+        for dst_dataset in merged_store[group_path]
+            name = PSI.HDF5.name(dst_dataset)
+            endswith(name, "__columns") && continue
+            compare_store_dataset(index, partition_store[name], dst_dataset, step_dim(dst_dataset))
+        end
+    end
+
+    PSI.HDF5.h5open(PSI._store_path(partition_results), "r") do merged_store
+        for index in 1:num_partitions
+            PSI.HDF5.h5open(
+                joinpath(PSI._partition_path(partition_results, index), PSI._store_subpath()),
+                "r",
+            ) do partition_store
+                @test sort(collect(keys(partition_store["simulation/decision_models"]))) ==
+                      sort(collect(keys(merged_store["simulation/decision_models"])))
+                for merged_group in merged_store["simulation/decision_models"]
+                    group_path = PSI.HDF5.name(merged_group)
+                    for output_type in string.(PSI.STORE_CONTAINERS)
+                        compare_store_group(
+                            index,
+                            partition_store,
+                            merged_store,
+                            "$group_path/$output_type",
+                            ndims,
+                        )
+                    end
+                    compare_store_dataset(
+                        index,
+                        partition_store["$group_path/optimizer_stats"],
+                        merged_store["$group_path/optimizer_stats"],
+                        ndims(merged_store["$group_path/optimizer_stats"]),
+                    )
+                end
+                for output_type in string.(PSI.STORE_CONTAINERS)
+                    compare_store_group(
+                        index,
+                        partition_store,
+                        merged_store,
+                        "simulation/emulation_model/$output_type",
+                        _ -> 1,
+                    )
+                end
+            end
+        end
+    end
+
+    # TODO: Can emulation model results be validated through the public results APIs?
+
+    # The checks below sabotage the partition outputs and so must be last.
+    joined_status_path = joinpath(base_dir, PSI.RESULTS_DIR)
     partition_status_path(index) =
         joinpath(PSI._partition_path(partition_results, index), PSI.RESULTS_DIR)
     read_realized(results) = Dict(

--- a/test/test_simulation_partitions.jl
+++ b/test/test_simulation_partitions.jl
@@ -33,6 +33,18 @@ end
     )
     @test PSI._is_interrupt(InterruptException())
     @test PSI._is_interrupt(remote)
+    interrupt_task = @async throw(InterruptException())
+    try
+        wait(interrupt_task)
+    catch
+    end
+    failed_task = @async error("failed")
+    try
+        wait(failed_task)
+    catch
+    end
+    @test PSI._is_interrupt(TaskFailedException(interrupt_task))
+    @test !PSI._is_interrupt(TaskFailedException(failed_task))
     @test PSI._is_interrupt(CompositeException([ErrorException("failed"), remote]))
     @test !PSI._is_interrupt(ErrorException("failed"))
     @test !PSI._is_interrupt(

--- a/test/test_simulation_partitions.jl
+++ b/test/test_simulation_partitions.jl
@@ -207,8 +207,10 @@ end
     )
     @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
 
-    # Options must be rejected if they are malformed or have an invalid value.
-    for invalid_option in ("--skip-failures=maybe", "--simulation-name=a=b")
+    # Options must be rejected if they are malformed, have an invalid value, or are
+    # missing a required value.
+    for invalid_option in
+        ("--skip-failures=maybe", "--simulation-name=a=b", "--simulation-name")
         @test_throws ErrorException PSI.process_simulation_partition_cli_args(
             build_simulation,
             execute_simulation,

--- a/test/test_simulation_partitions.jl
+++ b/test/test_simulation_partitions.jl
@@ -115,4 +115,147 @@ end
     end
 
     # TODO: Can emulation model results be validated?
+
+    # The checks below sabotage the partition outputs and so must be last.
+    base_dir = joinpath(sim_dir, partition_name)
+    partition_results = PSI.SimulationPartitionResults(base_dir)
+    joined_status_path = joinpath(base_dir, PSI.RESULTS_DIR)
+    num_partitions = get_num_partitions(partition_results.partitions)
+    partition_status_path(index) =
+        joinpath(PSI._partition_path(partition_results, index), PSI.RESULTS_DIR)
+    read_realized(results) = Dict(
+        name => read_realized_variables(
+            get_decision_problem_results(results, name);
+            table_format = TableFormat.WIDE,
+        ) for name in ("UC", "ED")
+    )
+
+    pre_join_variables = read_realized(partitioned_results)
+    failed_index = 2
+
+    # Joining a simulation with a failed partition must fail and record the failure.
+    PSI.serialize_status(PSI.RunStatus.FAILED, partition_status_path(failed_index))
+    @test_throws ErrorException PSI.join_simulation(base_dir)
+    @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
+
+    # Fill the merged store with a sentinel value in order to detect the steps that the
+    # next join writes. A skipped partition must not shift the data of the partitions
+    # that follow it.
+    sentinel = -9999.0
+    PSI.HDF5.h5open(joinpath(base_dir, "data_store", "simulation_store.h5"), "r+") do store
+        for group in store["simulation/decision_models"]
+            for output_type in string.(PSI.STORE_CONTAINERS)
+                for dataset in group[output_type]
+                    endswith(PSI.HDF5.name(dataset), "__columns") && continue
+                    if ndims(dataset) == 2
+                        dataset[:, :] = fill(sentinel, size(dataset))
+                    elseif ndims(dataset) == 3
+                        dataset[:, :, :] = fill(sentinel, size(dataset))
+                    else
+                        error("Unsupported dataset ndims: $(ndims(dataset))")
+                    end
+                end
+            end
+        end
+    end
+    # The results are read through the same conversions as any other results, so record
+    # what the sentinel looks like after them instead of assuming that it is unchanged.
+    store_dir = joinpath(base_dir, "data_store")
+    PSI.IS.compute_file_hash(store_dir, "simulation_store.h5")
+    sentinel_variables =
+        read_realized(SimulationResults(sim_dir, partition_name; ignore_status = true))
+
+    @test PSI.join_simulation(base_dir; skip_failures = true) == PSI.RunStatus.FAILED
+    @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
+    # The results of the successful partitions must still be readable.
+    post_join_results = SimulationResults(sim_dir, partition_name; ignore_status = true)
+    post_join_variables = read_realized(post_join_results)
+    for (model_name, pre_variables) in pre_join_variables
+        post_variables = post_join_variables[model_name]
+        @test sort(collect(keys(pre_variables))) == sort(collect(keys(post_variables)))
+        for (key, pre_df) in pre_variables
+            post_df = post_variables[key]
+            @test nrow(post_df) == nrow(pre_df)
+            @test nrow(pre_df) % num_partitions == 0
+            rows_per_step = nrow(pre_df) ÷ num_partitions
+            skipped_rows =
+                (rows_per_step * (failed_index - 1) + 1):(rows_per_step * failed_index)
+            merged_rows = setdiff(1:nrow(pre_df), skipped_rows)
+            # The successful partitions must be merged at their original steps.
+            @test post_df[merged_rows, :] == pre_df[merged_rows, :]
+            # The steps of the skipped partition must not be written. A join that writes
+            # nothing at all cannot pass this because the merged rows would hold the
+            # sentinel too.
+            @test post_df[skipped_rows, :] ==
+                  sentinel_variables[model_name][key][skipped_rows, :]
+        end
+    end
+
+    # The join command must behave the same way, with --skip-failures passed as a flag.
+    cli_args = ("join", "--simulation-name=$partition_name", "--output-dir=$sim_dir")
+    @test_throws ErrorException PSI.process_simulation_partition_cli_args(
+        build_simulation,
+        execute_simulation,
+        cli_args...,
+    )
+    @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
+    PSI.process_simulation_partition_cli_args(
+        build_simulation,
+        execute_simulation,
+        cli_args...,
+        "--skip-failures",
+    )
+    @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
+
+    # Options must be rejected if they are malformed or have an invalid value.
+    for invalid_option in ("--skip-failures=maybe", "--simulation-name=a=b")
+        @test_throws ErrorException PSI.process_simulation_partition_cli_args(
+            build_simulation,
+            execute_simulation,
+            cli_args...,
+            invalid_option,
+        )
+    end
+
+    PSI.serialize_status(
+        PSI.RunStatus.SUCCESSFULLY_FINALIZED,
+        partition_status_path(failed_index),
+    )
+
+    # A store file that cannot be read must be handled like a failed job, even if the job
+    # reported success.
+    corrupted_index = num_partitions
+    store_file = joinpath(
+        PSI._partition_path(partition_results, corrupted_index),
+        "data_store",
+        "simulation_store.h5",
+    )
+    store_backup = store_file * ".backup"
+    cp(store_file, store_backup)
+    try
+        write(store_file, "not an HDF5 file")
+        @test_throws Exception PSI.join_simulation(base_dir)
+        @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
+        @test PSI.join_simulation(base_dir; skip_failures = true) == PSI.RunStatus.FAILED
+        @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
+    finally
+        mv(store_backup, store_file; force = true)
+    end
+
+    # A job whose status cannot be read must be treated as a failure.
+    status_file = joinpath(partition_status_path(corrupted_index), "status.json")
+    status_backup = status_file * ".backup"
+    mv(status_file, status_backup)
+    try
+        @test_throws ErrorException PSI.join_simulation(base_dir)
+        @test PSI.deserialize_status(joined_status_path) == PSI.RunStatus.FAILED
+        @test PSI.join_simulation(base_dir; skip_failures = true) == PSI.RunStatus.FAILED
+    finally
+        mv(status_backup, status_file; force = true)
+    end
+
+    # With every job successful again, the join must succeed.
+    @test PSI.join_simulation(base_dir) == PSI.RunStatus.SUCCESSFULLY_FINALIZED
+    @test PSI.deserialize_status(joined_status_path) ==
+          PSI.RunStatus.SUCCESSFULLY_FINALIZED
 end


### PR DESCRIPTION
_check_jobs read the status of partition 1 for every index, so a partition that failed gracefully was never detected. The join then merged that partition's pre-allocated store and stamped the merged results SUCCESSFULLY_FINALIZED.

Impact:
- If a constituent simulation failed ungracefully because of OOM or walltime timeout, the simulation store file would have been corrupted and the join operation would have always failed. The rest of the impact section is not applicable.
- If a constituent simulation failed with a solver error, the joined simulation store file would have had holes of 0s in the result data for the failed days.
- The reference implementation for running via Distributed.jl threw an exception on any failure, so users of this workflow should have seen the failure.
- Users that ran partitioned simulations on an HPC with Jade would have seen the errors if they followed the standard procedures of checking workflow/job status, where the errors were clearly reported.
- Users that ran partitioned simulations on an HPC with Torc using the reference workflow implementation would have observed the join job not running at all - it would have been canceled because of the other failure(s), which torc would have clearly reported.

Read the status of each partition and, by default, record RunStatus.FAILED in the status file of the joined simulation and raise an error without merging. Add a skip_failures option (--skip-failures on the command line) that logs each failed partition, along with the simulation steps that it covers, and merges the results of the successful partitions. The status of the joined simulation is a failure either way.

Compute the destination offset of each dataset merge from the partition's absolute step range instead of the running write position so that a skipped partition does not shift the data of the partitions that follow it. Handle store files that are missing or corrupted the same way as failed jobs.

Support valueless flags in the command-line arguments.